### PR TITLE
Made rendered templates immutable

### DIFF
--- a/api/src/main/scala/twirl/api/BaseScalaTemplate.scala
+++ b/api/src/main/scala/twirl/api/BaseScalaTemplate.scala
@@ -3,6 +3,8 @@
  */
 package twirl.api
 
+import scala.collection.immutable
+
 case class BaseScalaTemplate[T <: Appendable[T], F <: Format[T]](format: F) {
 
   // The overloaded methods are here for speed. The compiled templates
@@ -10,7 +12,7 @@ case class BaseScalaTemplate[T <: Appendable[T], F <: Format[T]](format: F) {
   def _display_(x: AnyVal): T = format.escape(x.toString)
   def _display_(x: String): T = format.escape(x)
   def _display_(x: Unit): T = format.empty
-  def _display_(x: scala.xml.NodeSeq): T = format.raw(x.toString)
+  def _display_(x: scala.xml.NodeSeq): T = format.raw(x.toString())
   def _display_(x: T): T = x
 
   def _display_(o: Any)(implicit m: Manifest[T]): T = {
@@ -20,9 +22,10 @@ case class BaseScalaTemplate[T <: Appendable[T], F <: Format[T]](format: F) {
       case () => format.empty
       case None => format.empty
       case Some(v) => _display_(v)
-      case xml: scala.xml.NodeSeq => format.raw(xml.toString)
-      case escapeds: TraversableOnce[_] => format.fill(escapeds.map(_display_(_)))
-      case escapeds: Array[_] => format.fill(escapeds.toIterator.map(_display_(_)))
+      case xml: scala.xml.NodeSeq => format.raw(xml.toString())
+      case escapeds: immutable.Seq[_] => format.fill(escapeds.map(_display_))
+      case escapeds: TraversableOnce[_] => format.fill(escapeds.map(_display_).to[immutable.Seq])
+      case escapeds: Array[_] => format.fill(escapeds.view.map(_display_).to[immutable.Seq])
       case string: String => format.escape(string)
       case v if v != null => format.escape(v.toString)
       case _ => format.empty

--- a/api/src/main/scala/twirl/api/Content.scala
+++ b/api/src/main/scala/twirl/api/Content.scala
@@ -3,6 +3,8 @@
  */
 package twirl.api
 
+import scala.collection.immutable
+
 /**
  * Generic type representing content to be sent over an HTTP response.
  */
@@ -30,7 +32,7 @@ trait Content {
  * @param text Formatted content
  * @tparam A self-type
  */
-abstract class BufferedContent[A <: BufferedContent[A]](protected val elements: TraversableOnce[A], protected val text: String) extends Appendable[A] with Content { this: A =>
+abstract class BufferedContent[A <: BufferedContent[A]](protected val elements: immutable.Seq[A], protected val text: String) extends Appendable[A] with Content { this: A =>
   protected def buildString(builder: StringBuilder) {
     if (!elements.isEmpty) {
       elements.foreach { e =>

--- a/api/src/main/scala/twirl/api/Format.scala
+++ b/api/src/main/scala/twirl/api/Format.scala
@@ -3,6 +3,8 @@
  */
 package twirl.api
 
+import scala.collection.immutable
+
 /**
  * A type that works with BaseScalaTemplate
  * This used to support +=, but no longer is required to.
@@ -37,5 +39,5 @@ trait Format[T <: Appendable[T]] {
   /**
    * Fill an appendable with the elements
    */
-  def fill(elements: TraversableOnce[T]): T
+  def fill(elements: immutable.Seq[T]): T
 }

--- a/api/src/main/scala/twirl/api/Formats.scala
+++ b/api/src/main/scala/twirl/api/Formats.scala
@@ -4,6 +4,7 @@
 package twirl.api
 
 import org.apache.commons.lang3.StringEscapeUtils
+import scala.collection.immutable
 
 object MimeTypes {
   val TEXT       = "text/plain"
@@ -15,9 +16,9 @@ object MimeTypes {
 /**
  * Content type used in default HTML templates.
  */
-class Html private (elements: TraversableOnce[Html], text: String) extends BufferedContent[Html](elements, text) {
+class Html private (elements: immutable.Seq[Html], text: String) extends BufferedContent[Html](elements, text) {
   def this(text: String) = this(Nil, text)
-  def this(elements: TraversableOnce[Html]) = this(elements, "")
+  def this(elements: immutable.Seq[Html]) = this(elements, "")
 
   /**
    * Content type of HTML.
@@ -74,16 +75,16 @@ object HtmlFormat extends Format[Html] {
   /**
    * Create an HTML Fragment that holds other fragments.
    */
-  def fill(elements: TraversableOnce[Html]): Html = new Html(elements)
+  def fill(elements: immutable.Seq[Html]): Html = new Html(elements)
 
 }
 
 /**
  * Content type used in default text templates.
  */
-class Txt private (elements: TraversableOnce[Txt], text: String) extends BufferedContent[Txt](elements, text) {
+class Txt private (elements: immutable.Seq[Txt], text: String) extends BufferedContent[Txt](elements, text) {
   def this(text: String) = this(Nil, text)
-  def this(elements: TraversableOnce[Txt]) = this(elements, "")
+  def this(elements: immutable.Seq[Txt]) = this(elements, "")
 
   /**
    * Content type of text (`text/plain`).
@@ -128,16 +129,16 @@ object TxtFormat extends Format[Txt] {
   /**
    * Create an Txt Fragment that holds other fragments.
    */
-  def fill(elements: TraversableOnce[Txt]): Txt = new Txt(elements)
+  def fill(elements: immutable.Seq[Txt]): Txt = new Txt(elements)
 
 }
 
 /**
  * Content type used in default XML templates.
  */
-class Xml private (elements: TraversableOnce[Xml], text: String) extends BufferedContent[Xml](elements, text) {
+class Xml private (elements: immutable.Seq[Xml], text: String) extends BufferedContent[Xml](elements, text) {
   def this(text: String) = this(Nil, text)
-  def this(elements: TraversableOnce[Xml]) = this(elements, "")
+  def this(elements: immutable.Seq[Xml]) = this(elements, "")
 
   /**
    * Content type of XML (`application/xml`).
@@ -182,16 +183,16 @@ object XmlFormat extends Format[Xml] {
   /**
    * Create an XML Fragment that holds other fragments.
    */
-  def fill(elements: TraversableOnce[Xml]): Xml = new Xml(elements)
+  def fill(elements: immutable.Seq[Xml]): Xml = new Xml(elements)
 
 }
 
 /**
  * Type used in default JavaScript templates.
  */
-class JavaScript private (elements: TraversableOnce[JavaScript], text: String) extends BufferedContent[JavaScript](elements, text) {
+class JavaScript private (elements: immutable.Seq[JavaScript], text: String) extends BufferedContent[JavaScript](elements, text) {
   def this(text: String) = this(Nil, text)
-  def this(elements: TraversableOnce[JavaScript]) = this(elements, "")
+  def this(elements: immutable.Seq[JavaScript]) = this(elements, "")
 
   /**
    * Content type of JavaScript
@@ -235,6 +236,6 @@ object JavaScriptFormat extends Format[JavaScript] {
   /**
    * Create an JavaScript Fragment that holds other fragments.
    */
-  def fill(elements: TraversableOnce[JavaScript]): JavaScript = new JavaScript(elements)
+  def fill(elements: immutable.Seq[JavaScript]): JavaScript = new JavaScript(elements)
 
 }

--- a/build.sbt
+++ b/build.sbt
@@ -32,7 +32,8 @@ lazy val compiler = project
   .settings(
     name := "twirl-compiler",
     libraryDependencies += scalaCompiler(scalaVersion.value),
-    libraryDependencies += scalaIO(scalaBinaryVersion.value)
+    libraryDependencies += scalaIO(scalaBinaryVersion.value),
+    fork in run := true
   )
 
 lazy val plugin = project

--- a/compiler/src/test/resources/htmlParam.scala.html
+++ b/compiler/src/test/resources/htmlParam.scala.html
@@ -1,0 +1,5 @@
+@(content: Html)
+
+Content:
+
+@content

--- a/compiler/src/test/scala/twirl/compiler/test/Benchmark.scala
+++ b/compiler/src/test/scala/twirl/compiler/test/Benchmark.scala
@@ -1,0 +1,47 @@
+package twirl.compiler.test
+
+import twirl.api.Html
+import twirl.compiler.test.Helper.CompilerHelper
+import java.io.File
+
+/**
+ * Easiest way to run this:
+ *
+ * sbt compiler/test:runMain twirl.compiler.test.Benchmark
+ */
+object Benchmark extends App {
+
+  val sourceDir = new File("src/test/resources")
+  val generatedDir = new File("target/test/benchmark-templates")
+  val generatedClasses = new File("target/test/benchmark-classes")
+  scalax.file.Path(generatedDir).deleteRecursively()
+  scalax.file.Path(generatedClasses).deleteRecursively()
+  scalax.file.Path(generatedClasses).createDirectory()
+
+  val helper = new CompilerHelper(sourceDir, generatedDir, generatedClasses)
+
+  println("Compiling template...")
+  val template = helper.compile[((String, List[String]) => (Int) => Html)]("real.scala.html", "html.real")
+  val input = (1 to 100).map(_.toString).toList
+
+  // warmup
+  println("Warming up...")
+  for (i <- 1 to 10000) {
+    template("World", input)(4).body
+  }
+
+  println("Starting first run...")
+  val start1 = System.currentTimeMillis()
+  for (i <- 1 to 100000) {
+    template("World", input)(4).body
+  }
+  println(s"First run: ${System.currentTimeMillis() - start1}ms")
+
+  println("Starting second run...")
+  val start2 = System.currentTimeMillis()
+  for (i <- 1 to 100000) {
+    template("World", input)(4).body
+  }
+  println(s"Second run: ${System.currentTimeMillis() - start2}ms")
+
+}

--- a/compiler/src/test/scala/twirl/compiler/test/CompilerSpec.scala
+++ b/compiler/src/test/scala/twirl/compiler/test/CompilerSpec.scala
@@ -83,6 +83,16 @@ object CompilerSpec extends Specification {
       result.length must_== input.length
       result must_== input
     }
+
+    "allow rendering a template twice" in {
+      val helper = new CompilerHelper(sourceDir, generatedDir, generatedClasses)
+      val inner = helper.compile[((String, List[String]) => (Int) => Html)]("real.scala.html", "html.real")("World", List("A", "B"))(4)
+
+      val outer = helper.compile[Html => Html]("htmlParam.scala.html", "html.htmlParam")
+
+      outer(inner).body must contain("Hello World")
+      outer(inner).body must contain("Hello World")
+    }
   }
 
   "StringGrouper" should {
@@ -147,8 +157,6 @@ object Helper {
           compileErrors.append(CompilationError(msg, pos.line, pos.point))
         }
       })
-
-      new compiler.Run
 
       compiler
     }

--- a/compiler/src/test/scala/twirl/compiler/test/TemplateUtilsSpec.scala
+++ b/compiler/src/test/scala/twirl/compiler/test/TemplateUtilsSpec.scala
@@ -6,6 +6,7 @@ package test
 
 import org.specs2.mutable._
 import twirl.api._
+import scala.collection.immutable
 
 object TemplateUtilsSpec extends Specification {
 
@@ -27,7 +28,7 @@ object TemplateUtilsSpec extends Specification {
           def raw(text: String) = Html(text)
           def escape(text: String) = Html(text.replace("<", "&lt;"))
           def empty = Html("")
-          def fill(elements: TraversableOnce[Html]) = Html("")
+          def fill(elements: immutable.Seq[Html]) = Html("")
         }
 
         val html = HtmlFormat.raw("<h1>").body + HtmlFormat.escape("Hello <world>").body + HtmlFormat.raw("</h1>").body
@@ -45,7 +46,7 @@ object TemplateUtilsSpec extends Specification {
           def raw(text: String) = Text(text)
           def escape(text: String) = Text(text)
           def empty = Text("")
-          def fill(elements: TraversableOnce[Text]) = Text("")
+          def fill(elements: immutable.Seq[Text]) = Text("")
         }
 
         val text = TextFormat.raw("<h1>").body + TextFormat.escape("Hello <world>").body + TextFormat.raw("</h1>").body


### PR DESCRIPTION
Fixes https://github.com/playframework/playframework/issues/2676

This makes rendered templates use immutable.Seq instead of TraversableOnce.  See above issue for an extensive discussion of the implications of doing this.
