### PR TITLE
Add smarter implicit conversion for Option[Boolean] to Boolean

### DIFF
--- a/api/src/main/scala/play/twirl/api/TemplateMagic.scala
+++ b/api/src/main/scala/play/twirl/api/TemplateMagic.scala
@@ -18,6 +18,7 @@ object TemplateMagic {
   // --- IF
 
   implicit def iterableToBoolean(x: Iterable[_]) = x != null && !x.isEmpty
+  implicit def optionBooleanToBoolean(x: Option[Boolean]) = x != null && x == Some(true)
   implicit def optionToBoolean(x: Option[_]) = x != null && x.isDefined
   implicit def stringToBoolean(x: String) = x != null && !x.isEmpty
 

--- a/api/src/test/scala/play/twirl/api/test/TemplateMagicSpec.scala
+++ b/api/src/test/scala/play/twirl/api/test/TemplateMagicSpec.scala
@@ -1,0 +1,26 @@
+package play.twirl.api
+package test
+
+import org.specs2.mutable._
+
+object TemplateMagicSpec extends Specification {
+  import TemplateMagic._
+
+  "TemplateMagic" should {
+    "implicitly convert Option[_] to Boolean" in {
+      val value: Boolean = Some("foo")
+      value must beTrue
+    }
+
+    "implicit convert Some(true) to true" in {
+      val value: Boolean = Some(true)
+      value must beTrue
+    }
+
+    "implicit convert Some(false) to false" in {
+      val value: Boolean = Some(false)
+      value must beFalse
+    }
+  }
+
+}


### PR DESCRIPTION
`TemplateMagic` includes an implicit conversion for `Option[_] => Boolean`.  The current implementation creates unexpected behavior when implicitly converting `Option[Boolean]` where `Some(false)` implicitly converts to `true`.  This pull request adds a more specific implicit conversion to handle this case.

Behavior BEFORE:

```
Some(true) => true
Some(false) => true
Some("anything else") => true
```

Behavior AFTER:

```
Some(true) => true
Some(false) => false
Some("anything else") => true
```
