### PR TITLE
Default to scalac source encoding

### DIFF
--- a/compiler/src/main/scala/play/twirl/compiler/TwirlCompiler.scala
+++ b/compiler/src/main/scala/play/twirl/compiler/TwirlCompiler.scala
@@ -106,6 +106,8 @@ sealed trait AbstractGeneratedSource {
 
 case class GeneratedSource(file: File) extends AbstractGeneratedSource {
 
+  import TwirlCompiler.codec
+
   def content = TwirlIO.readFileAsString(file)
 
   def needRecompilation(imports: String): Boolean = !file.exists ||
@@ -151,7 +153,9 @@ case class GeneratedSourceVirtual(path: String) extends AbstractGeneratedSource 
 object TwirlCompiler {
   import play.twirl.parser.TreeNodes._
 
-  val codec = implicitly[Codec]
+  val encoding = sys.props.getOrElse("twirl.encoding", scala.util.Properties.sourceEncoding)
+
+  implicit val codec = Codec(encoding)
 
   def compile(source: File, sourceDirectory: File, generatedDirectory: File, formatterType: String, additionalImports: String = "", inclusiveDot: Boolean = false, useOldParser: Boolean = false) = {
     val resultType = formatterType + ".Appendable"


### PR DESCRIPTION
If scalac `-encoding` option is set to something other than default then `-Dtwirl.encoding` will also need to be set appropriately.

Resolves https://github.com/playframework/playframework/issues/2940
