### PR TITLE
Allow source encoding to be configured

### DIFF
--- a/parser/src/main/scala/play/twirl/parser/TwirlIO.scala
+++ b/parser/src/main/scala/play/twirl/parser/TwirlIO.scala
@@ -11,6 +11,10 @@ import java.net.URL
  */
 private[twirl] object TwirlIO {
 
+  val defaultEncoding = scala.util.Properties.sourceEncoding
+
+  val defaultCodec = Codec(defaultEncoding)
+
   /**
    * Read the given stream into a byte array.
    *
@@ -44,17 +48,17 @@ private[twirl] object TwirlIO {
    *
    * Does not close the stream.
    */
-  def readStreamAsString(stream: InputStream)(implicit codec: Codec): String = {
+  def readStreamAsString(stream: InputStream, codec: Codec = defaultCodec): String = {
     new String(readStream(stream), codec.name)
   }
 
   /**
    * Read the URL as a String.
    */
-  def readUrlAsString(url: URL)(implicit codec: Codec): String = {
+  def readUrlAsString(url: URL, codec: Codec = defaultCodec): String = {
     val is = url.openStream()
     try {
-      readStreamAsString(is)
+      readStreamAsString(is, codec)
     } finally {
       closeQuietly(is)
     }
@@ -63,10 +67,10 @@ private[twirl] object TwirlIO {
   /**
    * Read the file as a String.
    */
-  def readFileAsString(file: File)(implicit codec: Codec): String = {
+  def readFileAsString(file: File, codec: Codec = defaultCodec): String = {
     val is = new FileInputStream(file)
     try {
-      readStreamAsString(is)
+      readStreamAsString(is, codec)
     } finally {
       closeQuietly(is)
     }
@@ -75,7 +79,7 @@ private[twirl] object TwirlIO {
   /**
    * Write the given String to a file
    */
-  def writeStringToFile(file: File, contents: String)(implicit codec: Codec) = {
+  def writeStringToFile(file: File, contents: String, codec: Codec = defaultCodec) = {
     if (!file.getParentFile.exists) {
       file.getParentFile.mkdirs()
     }

--- a/sbt-twirl/src/main/scala/play/twirl/sbt/TemplateCompiler.scala
+++ b/sbt-twirl/src/main/scala/play/twirl/sbt/TemplateCompiler.scala
@@ -5,6 +5,7 @@ package play.twirl.sbt
 
 import sbt._
 import play.twirl.compiler._
+import scala.io.Codec
 
 object TemplateCompiler {
   def compile(
@@ -14,26 +15,27 @@ object TemplateCompiler {
     templateImports: Seq[String],
     includeFilter: FileFilter,
     excludeFilter: FileFilter,
+    codec: Codec,
     useOldParser: Boolean,
     log: Logger) = {
 
     try {
-      syncGenerated(targetDirectory)
+      syncGenerated(targetDirectory, codec)
       val templates = collectTemplates(sourceDirectories, templateFormats, includeFilter, excludeFilter)
       for ((template, sourceDirectory, extension, format) <- templates) {
         val imports = formatImports(templateImports, extension)
-        TwirlCompiler.compile(template, sourceDirectory, targetDirectory, format, imports, inclusiveDot = false, useOldParser = useOldParser)
+        TwirlCompiler.compile(template, sourceDirectory, targetDirectory, format, imports, codec, inclusiveDot = false, useOldParser = useOldParser)
       }
       generatedFiles(targetDirectory).map(_.getAbsoluteFile)
-    } catch handleError(log)
+    } catch handleError(log, codec)
   }
 
   def generatedFiles(targetDirectory: File): Seq[File] = {
     (targetDirectory ** "*.template.scala").get
   }
 
-  def syncGenerated(targetDirectory: File): Unit = {
-    generatedFiles(targetDirectory).map(GeneratedSource).foreach(_.sync)
+  def syncGenerated(targetDirectory: File, codec: Codec): Unit = {
+    generatedFiles(targetDirectory).map(GeneratedSource(_, codec)).foreach(_.sync)
   }
 
   def collectTemplates(sourceDirectories: Seq[File], templateFormats: Map[String, String], includeFilter: FileFilter, excludeFilter: FileFilter): Seq[(File, File, String, String)] = {
@@ -52,9 +54,9 @@ object TemplateCompiler {
     templateImports.map("import " + _.replace("%format%", extension)).mkString("\n")
   }
 
-  def handleError(log: Logger): PartialFunction[Throwable, Nothing] = {
+  def handleError(log: Logger, codec: Codec): PartialFunction[Throwable, Nothing] = {
     case TemplateCompilationError(source, message, line, column) =>
-      val exception = TemplateProblem.exception(source, message, line, column)
+      val exception = TemplateProblem.exception(source, codec, message, line, column)
       val reporter = new LoggerReporter(10, log)
       exception.problems foreach { p => reporter.display(p.position, p.message, p.severity) }
       throw exception


### PR DESCRIPTION
The source encoding is explicitly passed everywhere it's needed.

This allows sbt-twirl to configure the encoding, and to check for an exisiting `-encoding` setting in `scalacOptions`.
