### PR TITLE
Regress after unparsed case expressions

### DIFF
--- a/parser/src/main/scala/play/twirl/parser/TwirlParser.scala
+++ b/parser/src/main/scala/play/twirl/parser/TwirlParser.scala
@@ -518,7 +518,10 @@ class TwirlParser(val shouldParseInclusiveDot: Boolean) {
       if (blk != null) {
         result = ScalaExp(ListBuffer(pattern, blk))
         whitespace()
-      } else error("Expected block after 'case'")
+      } else {
+        //error("Expected block after 'case'")
+        input.regressTo(wspos)
+      }
     } else if (ws.length > 0) {
       // We could regress here and not return something for the ws, because the plain production rule
       // would parse this, but this would actually be a hotspot for backtracking, so let's return it

--- a/parser/src/test/resources/case.scala.js
+++ b/parser/src/test/resources/case.scala.js
@@ -1,0 +1,11 @@
+@()
+
+var varName = "ben";
+switch (varName) {
+   case "larry":
+       alert('Hey');
+       break;
+   default:
+       alert('hello world');
+       break;
+}

--- a/parser/src/test/scala/play/twirl/parser/test/OldParserSpec.scala
+++ b/parser/src/test/scala/play/twirl/parser/test/OldParserSpec.scala
@@ -74,6 +74,10 @@ object OldParserSpec extends Specification {
         ))
       }
 
+      "case.scala.js" in {
+        parseSuccess("case.scala.js")
+      }
+
     }
 
     "handle parentheses in string literals" in {

--- a/parser/src/test/scala/play/twirl/parser/test/ParserSpec.scala
+++ b/parser/src/test/scala/play/twirl/parser/test/ParserSpec.scala
@@ -76,6 +76,10 @@ object ParserSpec extends Specification {
         ))
       }
 
+      "case.scala.js" in {
+        parseSuccess("case.scala.js")
+      }
+
     }
 
     "handle string literals within parentheses" in {


### PR DESCRIPTION
Resolves https://github.com/playframework/twirl/issues/26

This aligns the behaviour with the old parser, which looks for a complete parse of `case (.+)=>` and a block.

A similar change was already made for match expressions: https://github.com/playframework/twirl/commit/b160c59a2dafbfd5a76e872ce3f44c68fb3f342f
