### PR TITLE
Update compiler spec to support spaces in build path

### DIFF
--- a/compiler/src/test/scala/play/twirl/compiler/test/CompilerSpec.scala
+++ b/compiler/src/test/scala/play/twirl/compiler/test/CompilerSpec.scala
@@ -166,7 +166,7 @@ object Helper {
     val compiler = {
 
       def additionalClassPathEntry: Option[String] = Some(
-        Class.forName("play.twirl.compiler.TwirlCompiler").getClassLoader.asInstanceOf[URLClassLoader].getURLs.map(_.getFile).mkString(":"))
+        Class.forName("play.twirl.compiler.TwirlCompiler").getClassLoader.asInstanceOf[URLClassLoader].getURLs.map(url => new File(url.toURI)).mkString(":"))
 
       val settings = new Settings
       val scalaObjectSource = Class.forName("scala.Option").getProtectionDomain.getCodeSource


### PR DESCRIPTION
See https://github.com/playframework/twirl/issues/38
