### PR TITLE
Add support for escaping closing braces

### DIFF
--- a/compiler/src/test/resources/escapebrace.scala.html
+++ b/compiler/src/test/resources/escapebrace.scala.html
@@ -1,0 +1,4 @@
+@(maybe: Option[String])
+@for(s <- maybe) {
+@s: @}
+}

--- a/compiler/src/test/scala/play/twirl/compiler/test/CompilerSpec.scala
+++ b/compiler/src/test/scala/play/twirl/compiler/test/CompilerSpec.scala
@@ -91,6 +91,12 @@ abstract class CompilerTests(oldParser: Boolean = false) extends Specification {
       result must be_==("<p>file: example, url: http://example.org</p>")
     }
 
+    "compile successfully (escape closing brace)" in {
+      val helper = newCompilerHelper
+      val result = helper.compile[(Option[String] => Html)]("escapebrace.scala.html", "html.escapebrace")(Some("foo")).toString.trim
+      result must be_==("foo: }")
+    }
+
     "compile successfully (utf8)" in {
       val helper = newCompilerHelper
       val text = helper.compile[(() => Html)]("utf8.scala.html", "html.utf8")().toString.trim

--- a/parser/src/main/scala/play/twirl/parser/PlayTwirlParser.scala
+++ b/parser/src/main/scala/play/twirl/parser/PlayTwirlParser.scala
@@ -49,6 +49,8 @@ class PlayTwirlParser extends JavaTokenParsers {
 
   def escapedAt = at ~> at
 
+  def escapedBrace = at ~> "}"
+
   def any = {
     Parser(in => if (in.atEnd) {
       Failure("end of file", in)
@@ -59,7 +61,7 @@ class PlayTwirlParser extends JavaTokenParsers {
 
   def plain: Parser[Plain] = {
     positioned(
-      ((escapedAt | (not(at) ~> (not("{" | "}") ~> any))) +) ^^ {
+      ((escapedAt | escapedBrace | (not(at) ~> (not("{" | "}") ~> any))) +) ^^ {
         case charList => Plain(charList.mkString)
       })
   }

--- a/parser/src/main/scala/play/twirl/parser/TwirlParser.scala
+++ b/parser/src/main/scala/play/twirl/parser/TwirlParser.scala
@@ -78,7 +78,7 @@ import scala.util.parsing.input.OffsetPosition
  *   comment : '@*' [^'*@']* '*@'
  *   parentheses : '(' (parentheses | [^')'])* ')'
  *   squareBrackets : '[' (squareBrackets | [^']'])* ']'
- *   plain : ('@@' | ([^'@'] [^'{' '}']))+
+ *   plain : ('@@' | '@}' | ([^'@'] [^'{' '}']))+
  *   whitespaceNoBreak : [' ' '\t']+
  *   identifier : javaIdentStart javaIdentPart* // see java docs for what these two rules mean
  * }}}
@@ -592,6 +592,7 @@ class TwirlParser(val shouldParseInclusiveDot: Boolean) {
   def plain(): Plain = {
     def single(): String = {
       if (check("@@")) "@"
+      else if (check("@}")) "}"
       else if (!input.isEOF() && input() != '@' && input() != '}' && input() != '{') any()
       else null
     }

--- a/parser/src/test/scala/play/twirl/parser/test/ParserSpec.scala
+++ b/parser/src/test/scala/play/twirl/parser/test/ParserSpec.scala
@@ -99,6 +99,10 @@ object ParserSpec extends Specification {
 
     }
 
+    "handle escaped closing curly braces" in {
+      parseStringSuccess("""@for(i <- is) { @} }""")
+    }
+
     "fail for" in {
 
       "unclosedBracket.scala.html" in {


### PR DESCRIPTION
Since Twirl uses closing brace to end blocks, if you want to put a closing brace into a block as ordinary text, you need to escape it.  This provides a convenient mechanism for escaping it, using @} as syntax.
