### PR TITLE
Clarify the exception thrown when template filenames have non accepted characters in them.

### DIFF
--- a/compiler/src/main/scala/play/twirl/compiler/TwirlCompiler.scala
+++ b/compiler/src/main/scala/play/twirl/compiler/TwirlCompiler.scala
@@ -260,7 +260,7 @@ object TwirlCompiler {
       case (f, name) if name == topDirectory => source2TemplateName(f.getParentFile, sourceDirectory, ext, name + "." + ext + "." + suffix, topDirectory, false)
       case (f, Name(name, _)) if f.isFile => source2TemplateName(f.getParentFile, sourceDirectory, ext, name, topDirectory, setExt)
       case (f, name) if !f.isFile => source2TemplateName(f.getParentFile, sourceDirectory, ext, name + "." + suffix, topDirectory, setExt)
-      case (f, name) => throw TemplateCompilationError(f, "Invalid template name [" + name + "]", 0, 0)
+      case (f, name) => throw TemplateCompilationError(f, "Invalid template name [" + name + "], filenames must only consist of alphanumeric characters and underscores or periods.", 0, 0)
     }
   }
 


### PR DESCRIPTION
I was having some trouble understanding what exactly was the problem, until I read the source code. Hopefully this makes sense to clarify what's required.

I've already signed the CLA from this PR: https://github.com/scala/community-builds/pull/49 
