### PR TITLE
Workaround for dbuild's scalaBinaryVersion mishandling.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -65,9 +65,17 @@ def common = Seq(
   scalacOptions := Seq("-unchecked", "-deprecation", "-encoding", "utf8")
 )
 
+def scalaSpecificSrcDirName(scalaBinaryVersion: String): String = scalaBinaryVersion match {
+  case "2.9.3" | "2.10" | "2.11" => s"scala-$scalaBinaryVersion"
+  // workaround for https://github.com/typesafehub/dbuild/issues/145
+  case other => "scala-2.11"
+}
+
 def crossScala = Seq(
-  crossScalaVersions := Seq("2.9.3", "2.10.4", "2.11.1"),
-  unmanagedSourceDirectories in Compile += (sourceDirectory in Compile).value / ("scala-" + scalaBinaryVersion.value)
+  crossScalaVersions := Seq("2.9.3", "2.10.4", "2.11.1"), {
+    unmanagedSourceDirectories in Compile +=
+      (sourceDirectory in Compile).value / scalaSpecificSrcDirName(scalaBinaryVersion.value)
+  }
 )
 
 def publishMaven = Seq(


### PR DESCRIPTION
This is another workaround for typesafehub/dbuild#145. This time we deal with
the problem of Scala version-dependent inclusion of source files to be
compiled. Selection of a source folder is broken because it is based on
scalaBinaryVersion which dbuild overrides. The workaround is to fallback to
"2.11" value for scalaBinaryVersion when the one set in the build is not
included in the known set ("2.9.3, "2.10", "2.11").
