### PR TITLE
HtmlFormat.escape loop performance

### DIFF
--- a/api/src/main/scala/play/twirl/api/Formats.scala
+++ b/api/src/main/scala/play/twirl/api/Formats.scala
@@ -19,10 +19,47 @@ object Formats {
 
 /**
  * Content type used in default HTML templates.
+ *
+ * This has 3 states, either it's a tree of elements, or a leaf, if it's a leaf, it's either safe text, or unsafe text
+ * that needs to be escaped when written out.
  */
-class Html private (elements: immutable.Seq[Html], text: String) extends BufferedContent[Html](elements, text) {
-  def this(text: String) = this(Nil, Formats.safe(text))
-  def this(elements: immutable.Seq[Html]) = this(elements, "")
+class Html private[api] (elements: immutable.Seq[Html], text: String, escape: Boolean) extends BufferedContent[Html](elements, text) {
+  def this(text: String) = this(Nil, Formats.safe(text), false)
+  def this(elements: immutable.Seq[Html]) = this(elements, "", false)
+
+  /**
+   * We override buildString for performance - allowing text to not be escaped until passed in the final StringBuilder
+   * to encode it into.
+   *
+   * An alternative way of implementing this would be to make HtmlFormat.escape return a subclass of Html with a custom
+   * buildString implementation.  While this does significantly improve performance if a template needs to escape a lot
+   * of Strings, if it doesn't, performance actually goes down (measured 10%), due to the fact that the JVM can't
+   * optimise the invocation of buildString as well because there are two different possible implementations.
+   */
+  override protected def buildString(builder: StringBuilder) {
+    if (!elements.isEmpty) {
+      elements.foreach { e =>
+        e.buildString(builder)
+      }
+    } else if (escape) {
+      // Using our own algorithm here because commons lang escaping wasn't designed for protecting against XSS, and there
+      // don't seem to be any other good generic escaping tools out there.
+      var i = 0
+      while (i < text.length) {
+        text.charAt(i) match {
+          case '<' => builder.append("&lt;")
+          case '>' => builder.append("&gt;")
+          case '"' => builder.append("&quot;")
+          case '\'' => builder.append("&#x27;")
+          case '&' => builder.append("&amp;")
+          case c => builder += c
+        }
+        i += 1
+      }
+    } else {
+      builder.append(text)
+    }
+  }
 
   /**
    * Content type of HTML.
@@ -57,18 +94,7 @@ object HtmlFormat extends Format[Html] {
    * Creates a safe (escaped) HTML fragment.
    */
   def escape(text: String): Html = {
-    // Using our own algorithm here because commons lang escaping wasn't designed for protecting against XSS, and there
-    // don't seem to be any other good generic escaping tools out there.
-    val sb = new StringBuilder(text.length)
-    text.foreach {
-      case '<' => sb.append("&lt;")
-      case '>' => sb.append("&gt;")
-      case '"' => sb.append("&quot;")
-      case '\'' => sb.append("&#x27;")
-      case '&' => sb.append("&amp;")
-      case c => sb += c
-    }
-    new Html(sb.toString)
+    new Html(Nil, text, true)
   }
 
   /**

--- a/compiler/src/test/scala/play/twirl/compiler/test/Benchmark.scala
+++ b/compiler/src/test/scala/play/twirl/compiler/test/Benchmark.scala
@@ -8,7 +8,7 @@ import play.twirl.parser.TwirlIO
 /**
  * Easiest way to run this:
  *
- * sbt compiler/test:runMain play.twirl.compiler.test.Benchmark
+ * sbt "compiler/test:runMain play.twirl.compiler.test.Benchmark"
  */
 object Benchmark extends App {
 
@@ -27,23 +27,25 @@ object Benchmark extends App {
   val template = helper.compile[((String, List[String]) => (Int) => Html)]("real.scala.html", "html.real")
   val input = (1 to 100).map(_.toString).toList
 
+  val text = "world " * 100
+
   // warmup
   println("Warming up...")
   for (i <- 1 to 10000) {
-    template("World", input)(4).body
+    template(text, input)(4).body
   }
 
   println("Starting first run...")
   val start1 = System.currentTimeMillis()
   for (i <- 1 to 100000) {
-    template("World", input)(4).body
+    template(text, input)(4).body
   }
   println("First run: " + (System.currentTimeMillis() - start1) + "ms")
 
   println("Starting second run...")
   val start2 = System.currentTimeMillis()
   for (i <- 1 to 100000) {
-    template("World", input)(4).body
+    template(text, input)(4).body
   }
   println("Second run: " + (System.currentTimeMillis() - start2) + "ms")
 


### PR DESCRIPTION
The following loop could probably be a bit faster if a `while` loop is used instead of a `foreach` expression. Might save some character boxing and the code would still be pretty simple.

```scala
  def escape(text: String): Html = {
    // Using our own algorithm here because commons lang escaping wasn't designed for protecting against XSS, and there
    // don't seem to be any other good generic escaping tools out there.
    val sb = new StringBuilder(text.length)
    text.foreach {
      case '<' => sb.append("&lt;")
      case '>' => sb.append("&gt;")
      case '"' => sb.append("&quot;")
      case '\'' => sb.append("&#x27;")
      case '&' => sb.append("&amp;")
      case c => sb += c
    }
    new Html(sb.toString)
  }
```

Cc @pvlugter.