### PR TITLE
Fix variable arguments with existential types

### DIFF
--- a/compiler/src/main/scala/play/twirl/compiler/TwirlCompiler.scala
+++ b/compiler/src/main/scala/play/twirl/compiler/TwirlCompiler.scala
@@ -402,11 +402,9 @@ object """ :+ name :+ """ extends BaseScalaTemplate[""" :+ resultType :+ """,For
 
     def getFunctionMapping(signature: String, returnType: String): (String, String, String) = synchronized {
 
-      def filterType(t: String) = t match {
-        case vararg if vararg.startsWith("_root_.scala.<repeated>") => vararg.replace("_root_.scala.<repeated>", "Array")
-        case synthetic if synthetic.contains("<synthetic>") => synthetic.replace("<synthetic>", "")
-        case t => t
-      }
+      def filterType(t: String) = t
+        .replace("_root_.scala.<repeated>", "Array")
+        .replace("<synthetic>", "")
 
       def findSignature(tree: Tree): Option[DefDef] = {
         tree match {

--- a/compiler/src/test/resources/varArgsExistential.scala.html
+++ b/compiler/src/test/resources/varArgsExistential.scala.html
@@ -1,0 +1,2 @@
+@(list: List[_]*)
+@list.map(_.mkString)

--- a/compiler/src/test/scala/play/twirl/compiler/test/CompilerSpec.scala
+++ b/compiler/src/test/scala/play/twirl/compiler/test/CompilerSpec.scala
@@ -117,6 +117,12 @@ abstract class CompilerTests(oldParser: Boolean = false) extends Specification {
       out must be_==("\"\"\"\n\n\"\"\"\"\"\n\n\"\"\"\"\"\"")
     }
 
+    "compile successfully (var args existential)" in {
+      val helper = newCompilerHelper
+      val text = helper.compile[(Array[List[_]] => Html)]("varArgsExistential.scala.html", "html.varArgsExistential")(Array(List(1, 2, 3), List(4, 5, 6))).toString.trim
+      text must be_==("123456")
+    }
+
     "fail compilation for error.scala.html" in {
       val helper = newCompilerHelper
       helper.compile[(() => Html)]("error.scala.html", "html.error") must throwA[CompilationError].like {


### PR DESCRIPTION
Previously, the following would not compile:

```
@(seq: Seq[_]*)
```

```
[info] Compiling 2 Scala sources to /home/paul/test11/target/scala-2.10/classes...
[error] /home/paul/test11/src/main/twirl/foo.scala.txt:1: illegal start of declaration
[error] @(seq: Seq[_]*)
[error] ^
[error] /home/paul/test11/src/main/twirl/foo.scala.txt:1: illegal start of declaration
[error] @(seq: Seq[_]*)
[error]                ^
[error] two errors found
[error] (compile:compile) Compilation failed
```