### PR TITLE
Make docs dependency on api an inter project dependency

### DIFF
--- a/docs/build.sbt
+++ b/docs/build.sbt
@@ -10,4 +10,9 @@ lazy val docs = project
     libraryDependencies += component("play-specs2") % "test",
     PlayDocsKeys.javaManualSourceDirectories := (baseDirectory.value / "manual" / "working" / "javaGuide" ** "code").get,
     PlayDocsKeys.scalaManualSourceDirectories := (baseDirectory.value / "manual" / "working" / "scalaGuide" ** "code").get
-  )
+  ).dependsOn(twirlApi)
+
+// the twirl plugin automatically adds this dependency, but this overrides it so
+// it can be an interproject dependency, rather than requiring it to be published
+// first
+lazy val twirlApi = ProjectRef(Path.fileProperty("user.dir").getParentFile, "api")


### PR DESCRIPTION
Although the twirl sbt plugin automatically adds a dependency on the correct version of the api dependency, that requires the dependency to be published first. This fix makes the dependency an inter project dependency, which fixes a problem in our travis build where if the API is changed, the docs build, which is a separate build from the main build, doesn't see the changes, for example as seen in #86.