### PR TITLE
Use unbescape for increased escaping performance

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -17,7 +17,7 @@ lazy val api = project
   .settings(common: _*)
   .settings(
     name := "twirl-api",
-    libraryDependencies += commonsLang,
+    libraryDependencies += "org.unbescape" % "unbescape" % "1.1.1.RELEASE",
     libraryDependencies ++= scalaXml(scalaVersion.value),
     libraryDependencies ++= specs2
   )
@@ -86,8 +86,6 @@ def generateVersionFile = Def.task {
 }
 
 // Dependencies
-
-def commonsLang = "org.apache.commons" % "commons-lang3" % "3.4"
 
 def scalaCompiler(version: String) = "org.scala-lang" % "scala-compiler" % version
 


### PR DESCRIPTION
Benchmarks for common escaping libraries at https://github.com/unbescape/unbescape-tests. (Some dependencies are a couple minor version behind. You can update them in pom.xml, though I saw no difference.)

Run them with

```sh
$ mvn3 exec:java -Dexec.mainClass=$BENCHMARK
```

where `$BENCHMARK` is html, xml, or javascript (or one of the other several formats that it supports). You can also see how each handles Unicode escapes, named character references, etc.

For me, unbescape was

**HTML**
* 2-14x the performance of commons-lang
* 3-8x the performance of esapi
* 0.5-1x the performance of spring-web

**XML**
* 3-15x the performance of commons-lang
* 2-12x the performance of esapi

**JS**
* 2-15x the performance of commons-lang

The higher differences are for inputs that needs no escaping. unbescape avoids `String` allocations entirely in that case.

The twirl HTML benchmarks came out to be the same as far as I could tell, though they don't test much.

In a production system, I saw 2x performance gain in templating large amounts of data in XML after switching to a custom `Format` using unbescape.

---

Have you considering using a benchmark framework, like ScalaMeter?

I wanted to add a couple benchmarks, but I wasn't sure what the best way was.