### PR TITLE
Wrong error source position mapping result on Windows.

### DIFF
--- a/sbt-twirl/src/main/scala/play/twirl/sbt/TemplateProblem.scala
+++ b/sbt-twirl/src/main/scala/play/twirl/sbt/TemplateProblem.scala
@@ -5,6 +5,7 @@ package play.twirl.sbt
 
 import sbt._
 import play.twirl.compiler.{ GeneratedSource, MaybeGeneratedSource }
+import play.twirl.parser.TwirlIO
 import xsbti.{ CompileFailed, Maybe, Position, Problem, Severity }
 import scala.io.Codec
 
@@ -48,7 +49,7 @@ object TemplateProblem {
   class TemplatePosition(source: Option[File], location: Option[TemplateMapping.Location]) extends Position {
     val line: Maybe[Integer] = maybe { location map (_.line) }
 
-    val lineContent: String = location.fold("")(_.content)
+    val lineContent: String = location.fold("")(_.content.stripSuffix("\r"))
 
     val offset: Maybe[Integer] = maybe { location map (_.offset) }
 
@@ -87,7 +88,7 @@ object TemplateProblem {
     }
 
     def apply(source: Option[File], codec: Codec): TemplateMapping = {
-      val lines = source.toSeq flatMap { file => IO.readLines(file, codec.charSet) }
+      val lines = source.toSeq flatMap { file => TwirlIO.readFileAsString(file, codec).split('\n') }
       TemplateMapping(lines)
     }
   }


### PR DESCRIPTION
Position in source template file calculated from generated Scala file works good only if new line sequences contain only one char . On Windows it's two-char sequence `\r\n` and this is not handled properly.

When loading the generated file `TwirlIO.readFileAsString` method is used and then content is split into lines using `split('\n')` method. This works well. See `compiler/src/main/scala/play/twirl/compiler/TwirlCompiler.scala`:
- `GeneratedSource.content` method:
```scala
  def content = TwirlIO.readFileAsString(file, codec)
```
https://github.com/playframework/twirl/blob/1.1.1/compiler/src/main/scala/play/twirl/compiler/TwirlCompiler.scala#L111
and
- `GeneratedSource.toSourcePosition` method:
```scala
      val line = TwirlIO.readFileAsString(source.get, codec).substring(0, targetMarker).split('\n').size
```
https://github.com/playframework/twirl/blob/1.1.1/compiler/src/main/scala/play/twirl/compiler/TwirlCompiler.scala#L121

When converting source file offset to (line, column) pair different `IO.readLines` method is used to load file content into lines sequence. See `sbt-twirl/src/main/scala/play/twirl/sbt/TemplateProblem.scala`:
```scala
      val lines = source.toSeq flatMap { file => IO.readLines(file, codec.charSet) }
```
https://github.com/playframework/twirl/blob/1.1.1/sbt-twirl/src/main/scala/play/twirl/sbt/TemplateProblem.scala#L90

This method uses `BufferedReader` under the hood and does not work properly here. You don't know, how many new line characters are consumed during `readLine` method calls. `TwirlIO.readFileAsString(file, codec).split('\n')` should be used.

When reading lines with a Reader you don't know, if new line sequences contain one (Linux) or two (Windows) characters. Line/position calculated from offset using this method is wrong on Windows. `TwirlIO.readFileAsString(file, codec).split('\n')` has to be used instead.

Additionally `\r` character has to be removed from the end of the line (it was consumed by `IO.readLines`, but it isn't with the new method).

This bug was found and solution well tested when implementing Play! Framework source position mappers in my [Maven plugin](https://github.com/play2-maven-plugin/play2-maven-plugin/issues/92).
