### PR TITLE
Injectable templates

### DIFF
--- a/api/src/main/scala/play/twirl/api/TemplateMagic.scala
+++ b/api/src/main/scala/play/twirl/api/TemplateMagic.scala
@@ -5,6 +5,7 @@ package play.twirl.api
 
 import scala.language.implicitConversions
 
+@deprecated("Use TwirlDefaultImports instead", "1.2.0")
 object TemplateMagic {
 
   // --- UTILS

--- a/api/src/main/scala/play/twirl/api/TwirlFeatureImports.scala
+++ b/api/src/main/scala/play/twirl/api/TwirlFeatureImports.scala
@@ -1,0 +1,54 @@
+/*
+ * Copyright (C) 2009-2014 Typesafe Inc. <http://www.typesafe.com>
+ */
+package play.twirl.api
+
+import scala.language.implicitConversions
+
+/**
+  * Imports that provide Twirl language features.
+  *
+  * This includes:
+  *
+  * - @defining
+  * - @using
+  * - iterable/option/string as boolean for if statements
+  * - default values (maybeFoo ? defaultFoo)
+  */
+object TwirlFeatureImports {
+
+  /**
+    * Provides the `@defining` language feature, that lets you set a local val that can be reused.
+    *
+    * @param t The defined val.
+    * @param handler The block to handle it.
+    */
+  def defining[T](t: T)(handler: T => Any): Any = {
+    handler(t)
+  }
+
+  /** Provides the `@using` language feature. */
+  def using[T](t: T): T = t
+
+  /** Adds "truthiness" to iterables, making them false if they are empty. */
+  implicit def twirlIterableToBoolean(x: Iterable[_]): Boolean = x != null && !x.isEmpty
+  /** Adds "truthiness" to options, making them false if they are empty. */
+  implicit def twirlOptionToBoolean(x: Option[_]): Boolean = x != null && x.isDefined
+  /** Adds "truthiness" to strings, making them false if they are empty. */
+  implicit def twirlStringToBoolean(x: String): Boolean = x != null && !x.isEmpty
+
+  /**
+    * Provides default values, such that an empty sequence, string, option, false boolean, or null will render
+    * the default value.
+    */
+  implicit class TwirlDefaultValue(default: Any) {
+    def ?:(x: Any): Any = x match {
+      case "" => default
+      case Nil => default
+      case false => default
+      case 0 => default
+      case None => default
+      case _ => x
+    }
+  }
+}

--- a/api/src/main/scala/play/twirl/api/TwirlHelperImports.scala
+++ b/api/src/main/scala/play/twirl/api/TwirlHelperImports.scala
@@ -1,0 +1,40 @@
+/*
+ * Copyright (C) 2009-2014 Typesafe Inc. <http://www.typesafe.com>
+ */
+package play.twirl.api
+
+import scala.language.implicitConversions
+
+/**
+  * Imports for useful Twirl helpers.
+  */
+object TwirlHelperImports {
+
+  /** Allows Java collections to be used as if they were Scala collections. */
+  implicit def twirlJavaCollectionToScala[T](x: java.lang.Iterable[T]): Iterable[T] = {
+    import scala.collection.JavaConverters._
+    x.asScala
+  }
+
+  /** Allows inline formatting of java.util.Date  */
+  implicit class TwirlRichDate(date: java.util.Date) {
+
+    def format(pattern: String): String = {
+      new java.text.SimpleDateFormat(pattern).format(date)
+    }
+
+  }
+
+  /** Adds a when method to Strings to control when they are rendered. */
+  implicit class TwirlRichString(string: String) {
+
+    def when(predicate: => Boolean): String = {
+      predicate match {
+        case true => string
+        case false => ""
+      }
+    }
+
+  }
+
+}

--- a/compiler/src/test/resources/importsDefault.scala.html
+++ b/compiler/src/test/resources/importsDefault.scala.html
@@ -1,2 +1,2 @@
 @()
-@Default.getClass.getName
+@{"" ?: "foo"}

--- a/compiler/src/test/resources/importsDefaultAdditional.scala.html
+++ b/compiler/src/test/resources/importsDefaultAdditional.scala.html
@@ -1,2 +1,0 @@
-@()
-@Default.getClass.getName

--- a/compiler/src/test/resources/importsDefaultAdditionalTemplate.scala.html
+++ b/compiler/src/test/resources/importsDefaultAdditionalTemplate.scala.html
@@ -1,3 +1,0 @@
-@import play.twirl.compiler.test.imports.foo._
-@()
-@Default.getClass.getName

--- a/compiler/src/test/resources/importsDefaultTemplate.scala.html
+++ b/compiler/src/test/resources/importsDefaultTemplate.scala.html
@@ -1,3 +1,0 @@
-@import play.twirl.compiler.test.imports.foo._
-@()
-@Default.getClass.getName

--- a/compiler/src/test/resources/inject.scala.html
+++ b/compiler/src/test/resources/inject.scala.html
@@ -1,0 +1,5 @@
+@this(a: String, b: Int)
+
+@(c: String)
+
+@a @b @c

--- a/compiler/src/test/resources/injectComments.scala.html
+++ b/compiler/src/test/resources/injectComments.scala.html
@@ -1,0 +1,18 @@
+@* Copyright 2016 Lightbend Inc *@
+
+@**
+ * A template
+ *
+ * @param a The a
+ * @param b The b
+ *@
+@this(a: String, b: Int)
+
+@**
+ * The method
+ *
+ * @param c The c
+ *@
+@(c: String)
+
+@a @b @c

--- a/compiler/src/test/resources/injectNoArgs.scala.html
+++ b/compiler/src/test/resources/injectNoArgs.scala.html
@@ -1,0 +1,5 @@
+@this()
+
+@(a: String)
+
+@a

--- a/compiler/src/test/resources/injectParamGroups.scala.html
+++ b/compiler/src/test/resources/injectParamGroups.scala.html
@@ -1,0 +1,5 @@
+@this(a: String)(b: Int)(implicit c: String)
+
+@(d: String)
+
+@a @b @c @d

--- a/compiler/src/test/scala/play/twirl/compiler/test/Benchmark.scala
+++ b/compiler/src/test/scala/play/twirl/compiler/test/Benchmark.scala
@@ -24,7 +24,7 @@ object Benchmark extends App {
   val helper = new CompilerHelper(sourceDir, generatedDir, generatedClasses)
 
   println("Compiling template...")
-  val template = helper.compile[((String, List[String]) => (Int) => Html)]("real.scala.html", "html.real")
+  val template = helper.compile[((String, List[String]) => (Int) => Html)]("real.scala.html", "html.real").static
   val input = (1 to 100).map(_.toString).toList
 
   val text = "world " * 100

--- a/compiler/src/test/scala/play/twirl/compiler/test/CompilerSpec.scala
+++ b/compiler/src/test/scala/play/twirl/compiler/test/CompilerSpec.scala
@@ -31,7 +31,7 @@ class CompilerSpec extends Specification {
 
     "compile successfully (real)" in {
       val helper = newCompilerHelper
-      helper.compile[((String, List[String]) => (Int) => Html)]("real.scala.html", "html.real")("World", List("A", "B"))(4).toString.trim must beLike {
+      helper.compile[((String, List[String]) => (Int) => Html)]("real.scala.html", "html.real").static("World", List("A", "B"))(4).toString.trim must beLike {
         case html =>
           {
             if (html.contains("<h1>Hello World</h1>") &&
@@ -44,14 +44,14 @@ class CompilerSpec extends Specification {
 
     "compile successfully (static)" in {
       val helper = newCompilerHelper
-      helper.compile[(() => Html)]("static.scala.html", "html.static")().toString.trim must be_==(
+      helper.compile[(() => Html)]("static.scala.html", "html.static").static().toString.trim must be_==(
         "<h1>It works</h1>")
     }
 
     "compile successfully (patternMatching)" in {
       val testParam = "12345"
       val helper = newCompilerHelper
-      helper.compile[((String) => Html)]("patternMatching.scala.html", "html.patternMatching")(testParam).toString.trim must be_==(
+      helper.compile[((String) => Html)]("patternMatching.scala.html", "html.patternMatching").static(testParam).toString.trim must be_==(
         """@test
 @test.length
 @test.length.toInt
@@ -66,79 +66,61 @@ class CompilerSpec extends Specification {
 
     "compile successfully (hello)" in {
       val helper = newCompilerHelper
-      val hello = helper.compile[((String) => Html)]("hello.scala.html", "html.hello")("World").toString.trim
+      val hello = helper.compile[((String) => Html)]("hello.scala.html", "html.hello").static("World").toString.trim
       hello must be_==("<h1>Hello World!</h1><h1>xml</h1>")
     }
 
     "compile successfully (helloNull)" in {
       val helper = newCompilerHelper
-      val hello = helper.compile[((String) => Html)]("helloNull.scala.html", "html.helloNull")(null).toString.trim
+      val hello = helper.compile[((String) => Html)]("helloNull.scala.html", "html.helloNull").static(null).toString.trim
       hello must be_==("<h1>Hello !</h1>")
     }
 
     "compile successfully (set)" in {
       val helper = newCompilerHelper
-      val set = helper.compile[((collection.immutable.Set[String]) => Html)]("set.scala.html", "html.set")(Set("first","second","third")).toString.trim.replace("\n","").replaceAll("\\s+", "")
+      val set = helper.compile[((collection.immutable.Set[String]) => Html)]("set.scala.html", "html.set").static(Set("first","second","third")).toString.trim.replace("\n","").replaceAll("\\s+", "")
       set must be_==("firstsecondthird")
     }
 
     "compile successfully (arg imports)" in {
       val helper = newCompilerHelper
-      val result = helper.compile[((java.io.File, java.net.URL) => Html)]("argImports.scala.html", "html.argImports")(new java.io.File("example"), new java.net.URL("http://example.org")).toString.trim
+      val result = helper.compile[((java.io.File, java.net.URL) => Html)]("argImports.scala.html", "html.argImports").static(new java.io.File("example"), new java.net.URL("http://example.org")).toString.trim
       result must be_==("<p>file: example, url: http://example.org</p>")
     }
 
     "compile successfully (default imports)" in {
       val helper = newCompilerHelper
-      val result = helper.compile[(() => Html)]("importsDefault.scala.html", "html.importsDefault")().toString.trim
-      result must be_==("play.twirl.api.TemplateMagic$Default$")
-    }
-
-    "compile successfully (additional imports beat default imports)" in {
-      val helper = newCompilerHelper
-      val result = helper.compile[(() => Html)]("importsDefaultAdditional.scala.html", "html.importsDefaultAdditional", additionalImports = "import play.twirl.compiler.test.imports.bar._")().toString.trim
-      result must be_==("play.twirl.compiler.test.imports.bar.Default$")
-    }
-
-    "compile successfully (template imports beat additional and default imports)" in {
-      val helper = newCompilerHelper
-      val result = helper.compile[(() => Html)]("importsDefaultAdditionalTemplate.scala.html", "html.importsDefaultAdditionalTemplate", additionalImports = "import play.twirl.compiler.test.imports.bar._")().toString.trim
-      result must be_==("play.twirl.compiler.test.imports.foo.Default$")
-    }
-
-    "compile successfully (template imports beat default imports)" in {
-      val helper = newCompilerHelper
-      val result = helper.compile[(() => Html)]("importsDefaultTemplate.scala.html", "html.importsDefaultTemplate")().toString.trim
-      result must be_==("play.twirl.compiler.test.imports.foo.Default$")
+      val result = helper.compile[(() => Html)]("importsDefault.scala.html", "html.importsDefault").static().toString.trim
+      result must be_==("foo")
     }
 
     "compile successfully (escape closing brace)" in {
       val helper = newCompilerHelper
-      val result = helper.compile[(Option[String] => Html)]("escapebrace.scala.html", "html.escapebrace")(Some("foo")).toString.trim
+      val result = helper.compile[(Option[String] => Html)]("escapebrace.scala.html", "html.escapebrace").static(Some("foo")).toString.trim
       result must be_==("foo: }")
     }
 
     "compile successfully (utf8)" in {
       val helper = newCompilerHelper
-      val text = helper.compile[(() => Html)]("utf8.scala.html", "html.utf8")().toString.trim
+      val text = helper.compile[(() => Html)]("utf8.scala.html", "html.utf8").static().toString.trim
       text must be_==("€, ö, or ü")
     }
 
     "compile successfully (existential)" in {
       val helper = newCompilerHelper
-      val text = helper.compile[(List[_] => Html)]("existential.scala.html", "html.existential")(List(1, 2, 3)).toString.trim
+      val text = helper.compile[(List[_] => Html)]("existential.scala.html", "html.existential").static(List(1, 2, 3)).toString.trim
       text must be_==("123")
     }
 
     "compile successfully (triple quotes)" in {
       val helper = newCompilerHelper
-      val out = helper.compile[(() => Html)]("triplequotes.scala.html", "html.triplequotes")().toString.trim
+      val out = helper.compile[(() => Html)]("triplequotes.scala.html", "html.triplequotes").static().toString.trim
       out must be_==("\"\"\"\n\n\"\"\"\"\"\n\n\"\"\"\"\"\"")
     }
 
     "compile successfully (var args existential)" in {
       val helper = newCompilerHelper
-      val text = helper.compile[(Array[List[_]] => Html)]("varArgsExistential.scala.html", "html.varArgsExistential")(Array(List(1, 2, 3), List(4, 5, 6))).toString.trim
+      val text = helper.compile[(Array[List[_]] => Html)]("varArgsExistential.scala.html", "html.varArgsExistential").static(Array(List(1, 2, 3), List(4, 5, 6))).toString.trim
       text must be_==("123456")
     }
 
@@ -153,19 +135,48 @@ class CompilerSpec extends Specification {
     "compile templates that have contiguous strings > than 64k" in {
       val helper = newCompilerHelper
       val input = TwirlIO.readFileAsString(new File(sourceDir, "long.scala.html"))
-      val result = helper.compile[(() => Html)]("long.scala.html", "html.long")().toString
+      val result = helper.compile[(() => Html)]("long.scala.html", "html.long").static().toString
       result.length must_== input.length
       result must_== input
     }
 
     "allow rendering a template twice" in {
       val helper = newCompilerHelper
-      val inner = helper.compile[((String, List[String]) => (Int) => Html)]("htmlInner.scala.html", "html.htmlInner")("World", List("A", "B"))(4)
+      val inner = helper.compile[((String, List[String]) => (Int) => Html)]("htmlInner.scala.html", "html.htmlInner").static("World", List("A", "B"))(4)
 
-      val outer = helper.compile[Html => Html]("htmlParam.scala.html", "html.htmlParam")
+      val outer = helper.compile[Html => Html]("htmlParam.scala.html", "html.htmlParam").static
 
       outer(inner).body must contain("Hello World")
       outer(inner).body must contain("Hello World")
+    }
+
+    "support injectable templates" in {
+
+      "plain injected template" in {
+        val helper = newCompilerHelper
+        val template = helper.compile[String => Html]("inject.scala.html", "html.inject").inject("Hello", 10)
+        template("world").body.trim must_== "Hello 10 world"
+      }
+
+      "with no args" in {
+        val helper = newCompilerHelper
+        val template = helper.compile[String => Html]("injectNoArgs.scala.html", "html.injectNoArgs").inject()
+        template("Hello").body.trim must_== "Hello"
+      }
+
+      "with parameter groups" in {
+        val helper = newCompilerHelper
+        val template = helper.compile[String => Html]("injectParamGroups.scala.html", "html.injectParamGroups").inject("Hello", 10, "my")
+        template("world").body.trim must_== "Hello 10 my world"
+      }
+
+      "with comments" in {
+        val helper = newCompilerHelper
+        val template = helper.compile[String => Html]("injectComments.scala.html", "html.injectComments").inject("Hello", 10)
+        template("world").body.trim must_== "Hello 10 world"
+      }
+
+
     }
   }
 
@@ -235,10 +246,28 @@ object Helper {
       compiler
     }
 
-    def compile[T](templateName: String, className: String, additionalImports: String = ""): T = {
+    class CompiledTemplate[T](className: String) {
+
+      private def getF(template: Any) = {
+        template.getClass.getMethod("f").invoke(template).asInstanceOf[T]
+      }
+
+      def static: T = {
+        getF(classloader.loadClass(className + "$").getDeclaredField("MODULE$").get(null))
+      }
+
+      def inject(constructorArgs: Any*): T = {
+        classloader.loadClass(className).getConstructors match {
+          case Array(single) => getF(single.newInstance(constructorArgs.asInstanceOf[Seq[AnyRef]]: _*))
+          case other => throw new IllegalStateException(className + " does not declare exactly one constructor: " + other)
+        }
+      }
+    }
+
+    def compile[T](templateName: String, className: String, additionalImports: Seq[String] = Nil): CompiledTemplate[T] = {
       val templateFile = new File(sourceDir, templateName)
       val Some(generated) = twirlCompiler.compile(templateFile, sourceDir, generatedDir, "play.twirl.api.HtmlFormat",
-        additionalImports = additionalImports)
+        additionalImports = TwirlCompiler.DefaultImports ++ additionalImports)
 
       val mapper = GeneratedSource(generated)
 
@@ -255,9 +284,8 @@ object Helper {
         }
       }
 
-      val t = classloader.loadClass(className + "$").getDeclaredField("MODULE$").get(null)
-
-      t.getClass.getMethod("f").invoke(t).asInstanceOf[T]
+      new CompiledTemplate[T](className)
     }
+
   }
 }

--- a/compiler/src/test/scala/play/twirl/compiler/test/TemplateUtilsSpec.scala
+++ b/compiler/src/test/scala/play/twirl/compiler/test/TemplateUtilsSpec.scala
@@ -13,7 +13,7 @@ object TemplateUtilsSpec extends Specification {
   "Templates" should {
 
     "provide a HASH util" in {
-      Hash("itShouldWork".getBytes, "") must be_==("31c0c4e0e142fe9b605fff44528fedb3dd8ae254")
+      Hash("itShouldWork".getBytes, Nil) must be_==("31c0c4e0e142fe9b605fff44528fedb3dd8ae254")
     }
 
     "provide a Format API" in {

--- a/docs/build.sbt
+++ b/docs/build.sbt
@@ -10,7 +10,19 @@ lazy val docs = project
     libraryDependencies += component("play-specs2") % "test",
     PlayDocsKeys.javaManualSourceDirectories := (baseDirectory.value / "manual" / "working" / "javaGuide" ** "code").get,
     PlayDocsKeys.scalaManualSourceDirectories := (baseDirectory.value / "manual" / "working" / "scalaGuide" ** "code").get
-  ).dependsOn(twirlApi)
+  ).settings(overrideTwirlSettings: _*)
+  .dependsOn(twirlApi)
+
+// The changes in Twirl imports cause a problem with the PlayDocsPlugin, which defines its own twirl compile tasks
+// and doesn't use the default imports provided by Twirl but defines its own by scratch, and since the defaults
+// have changed, this breaks.  So, first we need to set all source generators in test to Nil, then we can redefine the
+// twirl settings.
+def overrideTwirlSettings: Seq[Setting[_]] = Seq(
+  sourceGenerators in Test := Nil
+) ++ inConfig(Test)(SbtTwirl.twirlSettings) ++ SbtTwirl.defaultSettings ++ SbtTwirl.positionSettings ++ Seq(
+  sourceDirectories in (Test, TwirlKeys.compileTemplates) ++=
+    (PlayDocsKeys.javaManualSourceDirectories.value ++ PlayDocsKeys.scalaManualSourceDirectories.value)
+)
 
 // the twirl plugin automatically adds this dependency, but this overrides it so
 // it can be an interproject dependency, rather than requiring it to be published

--- a/docs/manual/working/javaGuide/main/templates/JavaTemplates.md
+++ b/docs/manual/working/javaGuide/main/templates/JavaTemplates.md
@@ -111,6 +111,18 @@ Or even several parameter groups:
 @(title:String)(body: Html)
 ```
 
+## Template constructor
+
+By default, a template is generated as a static function that can be invoked in any context.  If your template has dependencies on components, such as the messages API, you may find it easier to inject it with the components (and other templates) that it needs, and then you can inject that template into the controllers that use it.
+
+Twirl supports declaring a constructor for templates, using `@this()` syntax at the start of the file, before the template parameters.  The arguments to the constructor can be defined in the same way as the template parameters:
+
+```scala
+@this(messagesApi: MessagesApi)
+
+@(customer: models.Customer, orders: List[models.Order])
+```
+
 ## Iterating
 
 You can use the `for` keyword, in a pretty standard way:

--- a/docs/manual/working/scalaGuide/main/templates/ScalaTemplates.md
+++ b/docs/manual/working/scalaGuide/main/templates/ScalaTemplates.md
@@ -84,6 +84,14 @@ Or even several parameter groups:
 
 @[curried-parameters](code/scalaguide/templates/curriedParameters.scala.html)
 
+## Template constructor
+
+By default, a template is generated as a static function that can be invoked in any context.  If your template has dependencies on components, such as the messages API, you may find it easier to inject it with the components (and other templates) that it needs, and then you can inject that template into the controllers that use it.
+
+Twirl supports declaring a constructor for templates, using `@this()` syntax at the start of the file, before the template parameters.  The arguments to the constructor can be defined in the same way as the template parameters:
+
+@[constructor](code/scalaguide/templates/constructor.scala.html)
+
 ## Iterating
 
 You can use the `for` keyword, in a pretty standard way:

--- a/docs/manual/working/scalaGuide/main/templates/code/ScalaTemplates.scala
+++ b/docs/manual/working/scalaGuide/main/templates/code/ScalaTemplates.scala
@@ -6,26 +6,22 @@ package scalaguide.templates
 import org.specs2.mutable.Specification
 import play.twirl.api.Html
 
-// These have to be in the same package as the template
-package views.html.Application {
-  case class Order(title: String)
-  case class Customer(name: String)
+case class Order(title: String)
+case class Customer(name: String)
+case class Product(name: String, price: String)
+case class User(firstName: String, lastName: String)
+case class Article(content: String)
+
+case class MyComponent() {
+  override def toString = "MyComponent"
 }
 
-package html.models {
-  case class Order(title: String)
-  case class Customer(name: String)
-  case class Product(name: String, price: String)
-  case class User(firstName: String, lastName: String)
-  case class Article(content: String)
+case class MyFieldConstructor() {
+  val working = "implicit working"
+}
 
-  case class MyFieldConstructor() {
-    val working = "implicit working"
-  }
-
-  object ImplicitTester {
-    def test(implicit f: MyFieldConstructor) = f.working
-  }
+object ImplicitTester {
+  def test(implicit f: MyFieldConstructor) = f.working
 }
 
 package html.utils {
@@ -36,15 +32,12 @@ package html.utils {
 
 object ScalaTemplatesSpec extends Specification {
 
-  import html.models._
-
   val customer = Customer("mr customer")
   val orders = List(Order("foo"), Order("bar"))
 
 
   "Scala templates" should {
     "support an example template" in {
-      import views.html.Application._
 
       val c = Customer("mr customer")
       val o = List(Order("foo"), Order("bar"))
@@ -86,6 +79,14 @@ object ScalaTemplatesSpec extends Specification {
       val body = html.curriedParameters("foo")(Html("bar")).body
       body must contain("foo")
       body must contain("bar")
+    }
+
+    "allow constructors" in {
+      val body = new html.constructor(MyComponent())(customer, orders).body
+      body must contain("MyComponent")
+      body must contain(customer.toString)
+      body must contain(orders(0).toString)
+      body must contain(orders(1).toString)
     }
 
     "allow import statements" in {

--- a/docs/manual/working/scalaGuide/main/templates/code/scalaguide/templates/constructor.scala.html
+++ b/docs/manual/working/scalaGuide/main/templates/code/scalaguide/templates/constructor.scala.html
@@ -1,0 +1,9 @@
+@import scalaguide.templates._
+
+@* #constructor *@
+@this(myComponent: MyComponent)
+
+@(customer: Customer, orders: List[Order])
+@* #constructor *@
+
+@myComponent @customer @orders

--- a/docs/manual/working/scalaGuide/main/templates/code/scalaguide/templates/importStatement.scala.html
+++ b/docs/manual/working/scalaGuide/main/templates/code/scalaguide/templates/importStatement.scala.html
@@ -1,3 +1,5 @@
+@import scalaguide.templates._
+
 @* #import *@
 @(customer: Customer, orders: List[Order])
 

--- a/docs/manual/working/scalaGuide/main/templates/code/scalaguide/templates/simpleParameters.scala.html
+++ b/docs/manual/working/scalaGuide/main/templates/code/scalaguide/templates/simpleParameters.scala.html
@@ -1,3 +1,5 @@
+@import scalaguide.templates._
+
 @* #simple-parameters *@
 @(customer: Customer, orders: List[Order])
 @* #simple-parameters *@

--- a/docs/manual/working/scalaGuide/main/templates/code/scalaguide/templates/snippets.scala.html
+++ b/docs/manual/working/scalaGuide/main/templates/code/scalaguide/templates/snippets.scala.html
@@ -1,3 +1,5 @@
+@import scalaguide.templates._
+
 @(products: Seq[Product], user: User, article: Article)
 
 

--- a/docs/manual/working/scalaGuide/main/templates/code/scalaguide/templates/views/Application/index.scala.html
+++ b/docs/manual/working/scalaGuide/main/templates/code/scalaguide/templates/views/Application/index.scala.html
@@ -1,3 +1,4 @@
+@import scalaguide.templates._
 @* #example-template *@
 @(customer: Customer, orders: List[Order])
 

--- a/parser/src/main/scala/play/twirl/parser/TreeNodes.scala
+++ b/parser/src/main/scala/play/twirl/parser/TreeNodes.scala
@@ -10,7 +10,9 @@ object TreeNodes {
   abstract class ScalaExpPart
 
   case class Params(code: String) extends Positional
-  case class Template(name: PosString, comment: Option[Comment], params: PosString, topImports: Seq[Simple], imports: Seq[Simple], defs: Seq[Def], sub: Seq[Template], content: Seq[TemplateTree]) extends Positional
+  case class Constructor(comment: Option[Comment], params: PosString)
+  case class Template(name: PosString, constructor: Option[Constructor], comment: Option[Comment], params: PosString, topImports: Seq[Simple],
+    imports: Seq[Simple], defs: Seq[Def], sub: Seq[Template], content: Seq[TemplateTree]) extends Positional
   case class PosString(str: String) extends Positional {
     override def toString = str
   }

--- a/sbt-twirl/src/main/scala/play/twirl/sbt/SbtTwirl.scala
+++ b/sbt-twirl/src/main/scala/play/twirl/sbt/SbtTwirl.scala
@@ -3,6 +3,7 @@
  */
 package play.twirl.sbt
 
+import play.twirl.compiler.TwirlCompiler
 import sbt._
 import sbt.Keys._
 import scala.io.Codec
@@ -12,6 +13,7 @@ object Import {
     val twirlVersion = SettingKey[String]("twirl-version", "Twirl version used for twirl-api dependency")
     val templateFormats = SettingKey[Map[String, String]]("twirl-template-formats", "Defined twirl template formats")
     val templateImports = SettingKey[Seq[String]]("twirl-template-imports", "Extra imports for twirl templates")
+    val constructorAnnotations = SettingKey[Seq[String]]("twirl-constructor-annotations",  "Annotations added to constructors in injectable templates")
     @deprecated("No longer supported", "1.2.0")
     val useOldParser = SettingKey[Boolean]("twirl-use-old-parser", "No longer supported")
     val sourceEncoding = TaskKey[String]("twirl-source-encoding", "Source encoding for template files and generated scala files")
@@ -58,7 +60,8 @@ object SbtTwirl extends AutoPlugin {
 
   def defaultSettings: Seq[Setting[_]] = Seq(
     templateFormats := defaultFormats,
-    templateImports := Seq.empty,
+    templateImports := TwirlCompiler.DefaultImports,
+    constructorAnnotations := Nil,
     sourceEncoding := scalacEncoding(scalacOptions.value)
   )
 
@@ -89,6 +92,7 @@ object SbtTwirl extends AutoPlugin {
       (target in compileTemplates).value,
       templateFormats.value,
       templateImports.value,
+      constructorAnnotations.value,
       (includeFilter in compileTemplates).value,
       (excludeFilter in compileTemplates).value,
       Codec(sourceEncoding.value),

--- a/sbt-twirl/src/main/scala/play/twirl/sbt/TemplateCompiler.scala
+++ b/sbt-twirl/src/main/scala/play/twirl/sbt/TemplateCompiler.scala
@@ -18,14 +18,16 @@ object TemplateCompiler {
     excludeFilter: FileFilter,
     codec: Codec,
     useOldParser: Boolean,
-    log: Logger): Seq[File] = compile(sourceDirectories, targetDirectory, templateFormats, templateImports, includeFilter,
-    excludeFilter, codec, log)
+    log: Logger): Seq[File] =
+    compile(sourceDirectories, targetDirectory, templateFormats, templateImports, Nil, includeFilter, excludeFilter,
+      codec,  log)
 
   def compile(
     sourceDirectories: Seq[File],
     targetDirectory: File,
     templateFormats: Map[String, String],
     templateImports: Seq[String],
+    constructorAnnotations: Seq[String],
     includeFilter: FileFilter,
     excludeFilter: FileFilter,
     codec: Codec,
@@ -36,7 +38,8 @@ object TemplateCompiler {
       val templates = collectTemplates(sourceDirectories, templateFormats, includeFilter, excludeFilter)
       for ((template, sourceDirectory, extension, format) <- templates) {
         val imports = formatImports(templateImports, extension)
-        TwirlCompiler.compile(template, sourceDirectory, targetDirectory, format, imports, codec, inclusiveDot = false)
+        TwirlCompiler.compile(template, sourceDirectory, targetDirectory, format, imports, constructorAnnotations,
+          codec, inclusiveDot = false)
       }
       generatedFiles(targetDirectory).map(_.getAbsoluteFile)
     } catch handleError(log, codec)
@@ -62,8 +65,8 @@ object TemplateCompiler {
     }
   }
 
-  def formatImports(templateImports: Seq[String], extension: String): String = {
-    templateImports.map("import " + _.replace("%format%", extension)).mkString("\n")
+  def formatImports(templateImports: Seq[String], extension: String): Seq[String] = {
+    templateImports.map(_.replace("%format%", extension))
   }
 
   def handleError(log: Logger, codec: Codec): PartialFunction[Throwable, Nothing] = {


### PR DESCRIPTION
Requires #99 to be merged first.

Fixes #93 Fixes #71.

Adds support for injectable templates.

The syntax for this is:

    @this(...)

Multiple parameter lists and implicit parameters are supported.  The last comment before the constructor is used as the comment for the constructor in the generated scala code.

In addition to implementing this, I greatly improved the way start of the file is passed - you can now put comments between import statements, and as many comments as you want between the top import statements and the parameter declaration (previously, you could only have one comment there).  

There is one breaking change that I had to make to do this - previously imports were scoped using a nested object pattern, allowing imports in the templates to override the imports defined in sbt, and those imports to override the default imports.  This feature has been removed, all these imports are in the same scope.  To compensate, I've done the following:

* There are now no default hard coded imports, all imports are configured in sbt. This means they can be completely overridden.  This alleviates the need to have the default imports in a lower priority scope to the sbt imports.
* I've greatly limited what gets imported, there is no longer a blanket import on play.twirl.api._.  Only things that are needed are imported.
* I've deprecated TemplateMagic (it's not magic, bad name), and it no longer gets imported.  It's kept around for binary compatibility (so templates compiled with the old Twirl will still work).
* I've replaced TemplateMagic with two objects, TwirlFeatureImports, for features of the Twirl language, and TwirlHelperImports, for helpers.  In addition, all the symbols exposed by importing these two have been namespaced, so there should be no naming collisions, making it less necessary to scope imports.
* In general, going forward, we should discourage using imports defined in sbt, and limit what Play adds, since it generally introduces more confusion than not (why do I need to import this, but not something in the models package?)  Using Twirl should be closer to regular Scala in its rules and imports, the only things automatically imported should be things that are generally considered features of the Twirl language.  If this is followed, scoping imports shouldn't be needed.