### PR TITLE
Ask specs to run thread-unsafe ParserTest sequentially

### DIFF
--- a/parser/src/test/scala/play/twirl/parser/test/ParserSpec.scala
+++ b/parser/src/test/scala/play/twirl/parser/test/ParserSpec.scala
@@ -53,6 +53,8 @@ object ParserSpec extends Specification {
     }
   }
 
+  sequential
+
   "New twirl parser" should {
 
     "succeed for" in {


### PR DESCRIPTION
We noticed in the community build that `ParserTest` intermittently fails. I think this is likely due to the tests being run in parallel and accessing the a single instance of `TwirlParser`.

https://scala-ci.typesafe.com/view/scala-2.12.x/job/scala-2.12.x-integrate-community-build/433/console

```
[play-twirl] [info]     + case.scala.js
[play-twirl] [error]     ! import expressions
[play-twirl] [error]      java.lang.StringIndexOutOfBoundsException: String index out of range: 161 (TwirlParser.scala:115)
[play-twirl] [error] play.twirl.parser.TwirlParser$Input.apply(TwirlParser.scala:115)
[play-twirl] [error] play.twirl.parser.TwirlParser.any(TwirlParser.scala:227)
[play-twirl] [error] play.twirl.parser.TwirlParser.anyUntil(TwirlParser.scala:242)
[play-twirl] [error] play.twirl.parser.TwirlParser.importExpression(TwirlParser.scala:382)
[play-twirl] [error] play.twirl.parser.TwirlParser.extraImports(TwirlParser.scala:845)
[play-twirl] [error] play.twirl.parser.TwirlParser.parse(TwirlParser.scala:866)
[play-twirl] [error] play.twirl.parser.test.ParserSpec$.parseTemplateString(ParserSpec.scala:44)
[play-twirl] [error] play.twirl.parser.test.ParserSpec$.$anonfun$new$12(ParserSpec.scala:81)
[play-twirl] [error] play.twirl.parser.test.ParserSpec$.$anonfun$new$11(ParserSpec.scala:81)
[play-twirl] [info] 
[play-twirl] [info]   handle string literals within parentheses
```

```
[play-twirl] [info] New twirl parser should
[play-twirl] [info]   succeed for
[play-twirl] [error]     ! static.scala.html
[play-twirl] [error]      java.lang.StringIndexOutOfBoundsException: String index out of range: 17 (TwirlParser.scala:109)
[play-twirl] [error] play.twirl.parser.TwirlParser$Input.apply(TwirlParser.scala:109)
[play-twirl] [error] play.twirl.parser.TwirlParser.single$1(TwirlParser.scala:595)
[play-twirl] [error] play.twirl.parser.TwirlParser.plain(TwirlParser.scala:605)
[play-twirl] [error] play.twirl.parser.TwirlParser.opt1$1(TwirlParser.scala:434)
[play-twirl] [error] play.twirl.parser.TwirlParser.mixed(TwirlParser.scala:466)
[play-twirl] [error] play.twirl.parser.TwirlParser.templateContent(TwirlParser.scala:821)
[play-twirl] [error] play.twirl.parser.TwirlParser.parse(TwirlParser.scala:879)
[play-twirl] [error] play.twirl.parser.test.ParserSpec$.parseString(ParserSpec.scala:23)
[play-twirl] [error] play.twirl.parser.test.ParserSpec$.$anonfun$parseStringSuccess$1(ParserSpec.scala:30)
[play-twirl] [error] play.twirl.parser.test.ParserSpec$.parseStringSuccess(ParserSpec.scala:30)
[play-twirl] [error] play.twirl.parser.test.ParserSpec$.parseSuccess(ParserSpec.scala:27)
[play-twirl] [error] play.twirl.parser.test.ParserSpec$.$anonfun$new$3(ParserSpec.scala:58)
```
