### PR TITLE
Superseeds: Upgrade to Interplay 1.2.0 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ project/plugins/project/
 
 # Scala-IDE specific
 .scala_dependencies
+.idea

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,8 @@ script:
   - sbt +test +publishLocal plugin/test plugin/scripted
   - jdk_switcher use oraclejdk8 && cd docs && sbt test validateDocs
 sudo: false
+jdk:
+  - oraclejdk8
 cache:
   directories:
     - $HOME/.ivy2/cache

--- a/build.sbt
+++ b/build.sbt
@@ -1,13 +1,24 @@
 lazy val scalatest = "3.0.0"
+lazy val scala210 = "2.10.6"
+lazy val scala211 = "2.11.8"
+lazy val scala212 = "2.12.0-RC1"
 
 lazy val twirl = project
     .in(file("."))
     .enablePlugins(PlayRootProject)
+    .settings(
+      scalaVersion := scala210,
+      crossScalaVersions := List(scalaVersion.value, scala211, scala212)
+    )
     .aggregate(apiJvm, apiJs, parser, compiler)
 
 lazy val api = crossProject
     .in(file("api"))
     .enablePlugins(PlayLibrary, Playdoc)
+    .settings(
+      scalaVersion := scala210,
+      crossScalaVersions := List(scalaVersion.value, scala211, scala212)
+    )
     .settings(
       name := "twirl-api",
       libraryDependencies += "org.scalatest" %%% "scalatest" % scalatest % "test"
@@ -24,6 +35,10 @@ lazy val parser = project
     .in(file("parser"))
     .enablePlugins(PlayLibrary)
     .settings(
+      scalaVersion := scala210,
+      crossScalaVersions := List(scalaVersion.value, scala211, scala212)
+    )
+    .settings(
       name := "twirl-parser",
       libraryDependencies ++= scalaParserCombinators(scalaVersion.value),
       libraryDependencies += "org.scalatest" %%% "scalatest" % scalatest % "test"
@@ -33,6 +48,10 @@ lazy val compiler = project
     .in(file("compiler"))
     .enablePlugins(PlayLibrary)
     .dependsOn(apiJvm, parser % "compile;test->test")
+    .settings(
+      scalaVersion := scala210,
+      crossScalaVersions := List(scalaVersion.value, scala211, scala212)
+    )
     .settings(
       name := "twirl-compiler",
       libraryDependencies += scalaCompiler(scalaVersion.value),

--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,7 @@
 lazy val scalatest = "3.0.0"
 lazy val scala210 = "2.10.6"
 lazy val scala211 = "2.11.8"
-lazy val scala212 = "2.12.0-RC1"
+lazy val scala212 = "2.12.0-RC2"
 
 lazy val twirl = project
     .in(file("."))
@@ -68,7 +68,7 @@ lazy val plugin = project
       organization := "com.typesafe.sbt",
       libraryDependencies += "org.scalatest" %%% "scalatest" % scalatest % "test",
       // Plugin for %%%
-      addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.12"),
+      addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.13"),
       resourceGenerators in Compile <+= generateVersionFile,
       scriptedDependencies := {
         scriptedDependencies.value

--- a/docs/build.sbt
+++ b/docs/build.sbt
@@ -2,6 +2,7 @@ lazy val docs = project
   .in(file("."))
   .enablePlugins(PlayDocsPlugin)
   .settings(
+    scalaVersion := "2.11.8",
     // use special snapshot play version for now
     resolvers ++= DefaultOptions.resolvers(snapshot = true),
     resolvers += Resolver.typesafeRepo("releases"),

--- a/docs/project/plugins.sbt
+++ b/docs/project/plugins.sbt
@@ -4,4 +4,4 @@ lazy val sbtTwirl = ProjectRef(Path.fileProperty("user.dir").getParentFile, "plu
 
 resolvers ++= DefaultOptions.resolvers(snapshot = true)
 
-addSbtPlugin("com.typesafe.play" % "play-docs-sbt-plugin" % sys.props.getOrElse("play.version", "2.4.0-RC2"))
+addSbtPlugin("com.typesafe.play" % "play-docs-sbt-plugin" % sys.props.getOrElse("play.version", "2.5.6"))

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,4 +1,4 @@
-addSbtPlugin("com.typesafe.play" % "interplay" % sys.props.get("interplay.version").getOrElse("1.0.1"))
+addSbtPlugin("com.typesafe.play" % "interplay" % sys.props.get("interplay.version").getOrElse("1.2.0"))
 
 // For the Cross Build
 addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.12")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,4 +1,4 @@
 addSbtPlugin("com.typesafe.play" % "interplay" % sys.props.get("interplay.version").getOrElse("1.2.0"))
 
 // For the Cross Build
-addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.12")
+addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.13")


### PR DESCRIPTION
Actually twirl can't run without implicit `scalaVersion` and `crossScalaVersion`, since interplay will  actually change crossScalaVersion to 2.11.8, 2.12.0-M5 only, but on cross compilation with the plugin the first version of compiler and parser needs to be 2.10.6, `sbt` also can't detect that and fails with strange errors inside the docs project then.