### PR TITLE
upgrades scala to 2.12 and upgrades sbt to 0.13.13

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,7 @@
 lazy val scalatest = "3.0.0"
 lazy val scala210 = "2.10.6"
 lazy val scala211 = "2.11.8"
-lazy val scala212 = "2.12.0-RC2"
+lazy val scala212 = "2.12.0"
 
 lazy val twirl = project
     .in(file("."))
@@ -69,7 +69,7 @@ lazy val plugin = project
       libraryDependencies += "org.scalatest" %%% "scalatest" % scalatest % "test",
       // Plugin for %%%
       addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.13"),
-      resourceGenerators in Compile <+= generateVersionFile,
+      resourceGenerators in Compile += generateVersionFile.taskValue,
       scriptedDependencies := {
         scriptedDependencies.value
         publishLocal.all(ScopeFilter(
@@ -104,7 +104,7 @@ def scalaParserCombinators(scalaVersion: String) =
   whenAtLeast(scalaVersion, 2, 11, "org.scala-lang.modules" %% "scala-parser-combinators" % "1.0.4" % "optional")
 
 def scalaXml(scalaVersion: String) =
-  whenAtLeast(scalaVersion, 2, 11, "org.scala-lang.modules" %% "scala-xml" % "1.0.5")
+  whenAtLeast(scalaVersion, 2, 11, "org.scala-lang.modules" %% "scala-xml" % "1.0.6")
 
 def whenAtLeast(version: String, major: Int, minor: Int, module: ModuleID): Seq[ModuleID] = {
   CrossVersion.partialVersion(version) match {

--- a/docs/project/build.properties
+++ b/docs/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.12
+sbt.version=0.13.13

--- a/docs/project/plugins.sbt
+++ b/docs/project/plugins.sbt
@@ -4,4 +4,4 @@ lazy val sbtTwirl = ProjectRef(Path.fileProperty("user.dir").getParentFile, "plu
 
 resolvers ++= DefaultOptions.resolvers(snapshot = true)
 
-addSbtPlugin("com.typesafe.play" % "play-docs-sbt-plugin" % sys.props.getOrElse("play.version", "2.5.6"))
+addSbtPlugin("com.typesafe.play" % "play-docs-sbt-plugin" % sys.props.getOrElse("play.version", "2.5.9"))

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.12
+sbt.version=0.13.13

--- a/sbt-twirl/src/main/scala/play/twirl/sbt/SbtTwirl.scala
+++ b/sbt-twirl/src/main/scala/play/twirl/sbt/SbtTwirl.scala
@@ -46,20 +46,20 @@ object SbtTwirl extends AutoPlugin {
     excludeFilter in compileTemplates := HiddenFileFilter,
     sourceDirectories in compileTemplates := Seq(sourceDirectory.value / "twirl"),
 
-    sources in compileTemplates <<= Defaults.collectFiles(
+    sources in compileTemplates := Defaults.collectFiles(
       sourceDirectories in compileTemplates,
       includeFilter in compileTemplates,
       excludeFilter in compileTemplates
-    ),
+    ).value,
 
-    watchSources in Defaults.ConfigGlobal <++= sources in compileTemplates,
+    watchSources in Defaults.ConfigGlobal ++= (sources in compileTemplates).value,
 
     target in compileTemplates := crossTarget.value / "twirl" / Defaults.nameForSrc(configuration.value.name),
 
     compileTemplates := compileTemplatesTask.value,
 
-    sourceGenerators <+= compileTemplates,
-    managedSourceDirectories <+= target in compileTemplates
+    sourceGenerators += compileTemplates.taskValue,
+    managedSourceDirectories += (target in compileTemplates).value
   )
 
   def defaultSettings: Seq[Setting[_]] = Seq(


### PR DESCRIPTION
Finally

P.S.: if publishing make the version at least `1.3.x` due to: https://github.com/playframework/twirl/commit/ff7b4b3dd73e4d3889c0d1c0aa7ab403c8a5f3c6 and https://github.com/playframework/twirl/commit/104128a41ed3cecfd329f1721d5f7ae4cf0286d7 which are binary incompatible with `1.2.x`. After that play-docs can be upgraded/published and then playframework :-)