### PR TITLE
Add twirl dependency injection docs

### DIFF
--- a/docs/manual/working/javaGuide/main/templates/JavaTemplatesDependencyInjection.md
+++ b/docs/manual/working/javaGuide/main/templates/JavaTemplatesDependencyInjection.md
@@ -1,22 +1,22 @@
 # Dependency Injection with Templates
 
-Twirl templates can now be created with a constructor annotation using `@this`.  The constructor annotation means that Twirl templates can be injected into templates directly and can manage their own dependencies, rather than the controller having to manage dependencies not only for itself, but also for the templates it has to render.
+Twirl templates can be generated as a class rather than a static object by declaring a constructor using a special @this(args) syntax at the top of the template. This means that Twirl templates can be injected into controllers directly and can manage their own dependencies, rather than the controller having to manage dependencies not only for itself, but also for the templates it has to render.
 
-As an example, suppose a template has a dependency on a component `TemplateRenderingComponent`, which is not used by the controller.  
+As an example, suppose a template has a dependency on a component `Summarizer`, which is not used by the controller:
 
-First, add the `@Inject` annotation to Twirl in `build.sbt`:
+```java
+public interface Summarizer {
+  /** Provide short form of string if over a certain length */
+  String summarize(String item);
+}
+
+Create a file `app/views/IndexTemplate.scala.html` using the `@this` syntax for the constructor:
 
 ```scala
-TwirlKeys.constructorAnnotations += "@javax.inject.Inject()"
-```
+@this(summarizer: Summarizer)
+@(item: String)
 
-Then create a file `indexTemplate.scala.html` using the `@this` syntax for the constructor:
-
-```scala
-@this(trc: TemplateRenderingComponent)
-@()
-
-@{trc.render(item)}
+@{summarizer.summarize(item)}
 ```
 
 And finally define the controller in Play by injecting the template in the constructor:
@@ -24,18 +24,27 @@ And finally define the controller in Play by injecting the template in the const
 ```java
 public class MyController extends Controller {
   
-  private final views.html.indexTemplate template;
+  private final views.html.IndexTemplate template;
 
   @Inject
-  public MyController(views.html.indexTemplate template) {
+  public MyController(views.html.IndexTemplate template) {
     this.template = template;
   }
 
   public Result index() {
-    return ok(template.render());
+    String item = "some extremely long text";
+    return ok(template.render(item));
   }
 
 }
 ```
 
-Once the template is defined with its dependencies, then the controller can have the template injected into the controller, but the controller does not see `TemplateRenderingComponent`.
+Once the template is defined with its dependencies, then the controller can have the template injected into the controller, but the controller does not see `Summarizer`.
+
+If you are using Twirl outside of a Play application, you will have to manually add the `@Inject` annotation saying that dependency injection should be used here:
+
+```scala
+TwirlKeys.constructorAnnotations += "@javax.inject.Inject()"
+```
+
+Inside a play application, this is already included in the default settings.

--- a/docs/manual/working/javaGuide/main/templates/JavaTemplatesDependencyInjection.md
+++ b/docs/manual/working/javaGuide/main/templates/JavaTemplatesDependencyInjection.md
@@ -1,0 +1,41 @@
+# Dependency Injection with Templates
+
+Twirl templates can now be created with a constructor annotation using `@this`.  The constructor annotation means that Twirl templates can be injected into templates directly and can manage their own dependencies, rather than the controller having to manage dependencies not only for itself, but also for the templates it has to render.
+
+As an example, suppose a template has a dependency on a component `TemplateRenderingComponent`, which is not used by the controller.  
+
+First, add the `@Inject` annotation to Twirl in `build.sbt`:
+
+```scala
+TwirlKeys.constructorAnnotations += "@javax.inject.Inject()"
+```
+
+Then create a file `indexTemplate.scala.html` using the `@this` syntax for the constructor:
+
+```scala
+@this(trc: TemplateRenderingComponent)
+@()
+
+@{trc.render(item)}
+```
+
+And finally define the controller in Play by injecting the template in the constructor:
+
+```java
+public class MyController extends Controller {
+  
+  private final views.html.indexTemplate template;
+
+  @Inject
+  public MyController(views.html.indexTemplate template) {
+    this.template = template;
+  }
+
+  public Result index() {
+    return ok(template.render());
+  }
+
+}
+```
+
+Once the template is defined with its dependencies, then the controller can have the template injected into the controller, but the controller does not see `TemplateRenderingComponent`.

--- a/docs/manual/working/javaGuide/main/templates/index.toc
+++ b/docs/manual/working/javaGuide/main/templates/index.toc
@@ -1,3 +1,4 @@
 JavaTemplates:Templates syntax
+JavaTemplatesDependencyInjection:Dependency Injection with Templates
 JavaTemplateUseCases:Common use cases
 JavaCustomTemplateFormat:Custom formats

--- a/docs/manual/working/scalaGuide/main/templates/ScalaTemplatesDependencyInjection.md
+++ b/docs/manual/working/scalaGuide/main/templates/ScalaTemplatesDependencyInjection.md
@@ -1,0 +1,35 @@
+# Dependency Injection with Templates
+
+Twirl templates can now be created with a constructor annotation using `@this`.  The constructor annotation means that Twirl templates can be injected into templates directly and can manage their own dependencies, rather than the controller having to manage dependencies not only for itself, but also for the templates it has to render.
+
+As an example, suppose a template has a dependency on a component `TemplateRenderingComponent`, which is not used by the controller.  
+
+First, add the `@Inject` annotation to Twirl in `build.sbt`:
+
+```scala
+TwirlKeys.constructorAnnotations += "@javax.inject.Inject()"
+```
+
+Then create a file `indexTemplate.scala.html` using the `@this` syntax for the constructor:
+
+```scala
+@this(trc: TemplateRenderingComponent)
+@()
+
+@{trc.render(item)}
+```
+
+And finally define the controller by injecting the template in the constructor:
+
+```scala
+public MyController @Inject()(template: views.html.indexTemplate, 
+                              cc: ControllerComponents) 
+  extends AbstractController(cc) {
+  
+  def index = Action { implicit request =>
+    Ok(template())
+  }
+}
+```
+
+Once the template is defined with its dependencies, then the controller can have the template injected into the controller, but the controller does not see `TemplateRenderingComponent`.

--- a/docs/manual/working/scalaGuide/main/templates/ScalaTemplatesDependencyInjection.md
+++ b/docs/manual/working/scalaGuide/main/templates/ScalaTemplatesDependencyInjection.md
@@ -1,35 +1,44 @@
 # Dependency Injection with Templates
 
-Twirl templates can now be created with a constructor annotation using `@this`.  The constructor annotation means that Twirl templates can be injected into templates directly and can manage their own dependencies, rather than the controller having to manage dependencies not only for itself, but also for the templates it has to render.
+Twirl templates can be generated as a class rather than a static object by declaring a constructor using a special @this(args) syntax at the top of the template. This means that Twirl templates can be injected into controllers directly and can manage their own dependencies, rather than the controller having to manage dependencies not only for itself, but also for the templates it has to render.
 
-As an example, suppose a template has a dependency on a component `TemplateRenderingComponent`, which is not used by the controller.  
+As an example, suppose a template has a dependency on a component `Summarizer`, which is not used by the controller:
 
-First, add the `@Inject` annotation to Twirl in `build.sbt`:
+```scala
+trait Summarizer {
+  /** Provide short form of string if over a certain length */
+  def summarize(item: String)
+}
+
+Create a file `app/views/IndexTemplate.scala.html` using the `@this` syntax for the constructor:
+
+```scala
+@this(summarizer: Summarizer)
+@(item: String)
+
+@{summarizer.summarize(item)}
+```
+
+And finally define the controller in Play by injecting the template in the constructor:
+
+```scala
+public MyController @Inject()(template: views.html.IndexTemplate, 
+                              cc: ControllerComponents) 
+  extends AbstractController(cc) {
+  
+  def index = Action { implicit request =>
+    val item = "some extremely long text"
+    Ok(template(item))
+  }
+}
+```
+
+Once the template is defined with its dependencies, then the controller can have the template injected into the controller, but the controller does not see `Summarizer`.
+
+If you are using Twirl outside of a Play application, you will have to manually add the `@Inject` annotation saying that dependency injection should be used here:
 
 ```scala
 TwirlKeys.constructorAnnotations += "@javax.inject.Inject()"
 ```
 
-Then create a file `indexTemplate.scala.html` using the `@this` syntax for the constructor:
-
-```scala
-@this(trc: TemplateRenderingComponent)
-@()
-
-@{trc.render(item)}
-```
-
-And finally define the controller by injecting the template in the constructor:
-
-```scala
-public MyController @Inject()(template: views.html.indexTemplate, 
-                              cc: ControllerComponents) 
-  extends AbstractController(cc) {
-  
-  def index = Action { implicit request =>
-    Ok(template())
-  }
-}
-```
-
-Once the template is defined with its dependencies, then the controller can have the template injected into the controller, but the controller does not see `TemplateRenderingComponent`.
+Inside a play application, this is already included in the default settings.

--- a/docs/manual/working/scalaGuide/main/templates/index.toc
+++ b/docs/manual/working/scalaGuide/main/templates/index.toc
@@ -1,3 +1,4 @@
-ScalaTemplates:Scala templates syntax
+ScalaTemplates:Templates syntax
+ScalaTemplatesDependencyInjection:Dependency Injection with Templates
 ScalaTemplateUseCases:Common use cases
 ScalaCustomTemplateFormat:Custom format


### PR DESCRIPTION
Adds doc showing how to use twirl constructor annotation

This is tied to Play when the rest of the doc is independent, but
this seems to be a case where it wouldn't be clear why you were 
doing this otherwise...