### PR TITLE
Add a Java compiler API to call from Maven and Gradle

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -40,6 +40,7 @@ lazy val parser = project
     .settings(
       name := "twirl-parser",
       libraryDependencies ++= scalaParserCombinators(scalaVersion.value),
+      libraryDependencies += "com.novocode" % "junit-interface" % "0.11" % "test",
       libraryDependencies += "org.scalatest" %%% "scalatest" % scalatest % "test"
     )
 

--- a/compiler/src/main/java/play/japi/twirl/compiler/TwirlCompiler.java
+++ b/compiler/src/main/java/play/japi/twirl/compiler/TwirlCompiler.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (C) 2017 Typesafe Inc. <http://www.typesafe.com>
+ */
+package play.japi.twirl.compiler;
+
+import java.io.File;
+import java.nio.charset.Charset;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import scala.collection.JavaConverters$;
+import scala.collection.Seq;
+import scala.io.Codec;
+import scala.util.Properties$;
+
+public class TwirlCompiler {
+
+  public static final Set<String> DEFAULT_IMPORTS;
+  static {
+    Set<String> imports = new HashSet<>();
+    imports.addAll(JavaConverters$.MODULE$
+        .seqAsJavaListConverter(play.twirl.compiler.TwirlCompiler$.MODULE$.DefaultImports()).asJava());
+    DEFAULT_IMPORTS = Collections.unmodifiableSet(imports);
+  }
+
+  public static Optional<File> compile(File source, File sourceDirectory, File generatedDirectory, String formatterType,
+      Collection<String> additionalImports, List<String> constructorAnnotations) {
+    Charset sourceEncoding = Charset.forName(Properties$.MODULE$.sourceEncoding());
+    return compile(source, sourceDirectory, generatedDirectory, formatterType, additionalImports,
+        constructorAnnotations, new Codec(sourceEncoding), false);
+  }
+
+  public static Optional<File> compile(File source, File sourceDirectory, File generatedDirectory, String formatterType,
+      Collection<String> additionalImports, List<String> constructorAnnotations, Codec codec, boolean inclusiveDot) {
+    Seq<String> scalaAdditionalImports = JavaConverters$.MODULE$.asScalaBufferConverter(new ArrayList<String>(additionalImports)).asScala();
+    Seq<String> scalaConstructorAnnotations = JavaConverters$.MODULE$.asScalaBufferConverter(constructorAnnotations).asScala();
+    return Optional.ofNullable(play.twirl.compiler.TwirlCompiler.compile(source, sourceDirectory, generatedDirectory,
+        formatterType, scalaAdditionalImports, scalaConstructorAnnotations, codec, inclusiveDot).getOrElse(null));
+  }
+
+}

--- a/compiler/src/test/java/play/japi/twirl/compiler/TwirlCompilerTest.java
+++ b/compiler/src/test/java/play/japi/twirl/compiler/TwirlCompilerTest.java
@@ -1,0 +1,57 @@
+package play.japi.twirl.compiler;
+
+import static org.junit.Assert.*;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.FileVisitResult;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.SimpleFileVisitor;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.util.ArrayList;
+import java.util.Optional;
+import org.junit.Test;
+
+public class TwirlCompilerTest {
+
+  @Test
+  public void compile() {
+    File sourceDirectory = new File("compiler/src/test/resources");
+    File source = new File(sourceDirectory, "real.scala.html");
+    File generatedDirectory = new File("compiler/target/test/japi-compiler/generated-templates");
+
+    deleteRecursively(generatedDirectory);
+    generatedDirectory.mkdirs();
+
+    Optional<File> result = TwirlCompiler.compile(source, sourceDirectory, generatedDirectory, "play.twirl.api.HtmlFormat",
+        TwirlCompiler.DEFAULT_IMPORTS, new ArrayList<String>());
+    assertTrue(result.isPresent());
+  }
+
+  private static void deleteRecursively(File directory) {
+    if (!directory.exists()) {
+      return;
+    }
+    Path path = directory.toPath();
+    try {
+      Files.walkFileTree(path, new SimpleFileVisitor<Path>() {
+        @Override
+        public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) throws IOException {
+          Files.delete(file);
+          return FileVisitResult.CONTINUE;
+        }
+
+        @Override
+        public FileVisitResult postVisitDirectory(Path dir, IOException exc) throws IOException {
+          Files.delete(dir);
+          return FileVisitResult.CONTINUE;
+        }
+      });
+    } catch(IOException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+}


### PR DESCRIPTION
I've needed this code for both the Maven and Gradle plugins which are written in Java. Seems better to have it live here in a common location than have to duplicate it in both plugins.