### PR TITLE
Add crossbuilding for sbt 1.0

### DIFF
--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.15
+sbt.version=0.13.16-M1


### PR DESCRIPTION
Fixes https://github.com/playframework/twirl/issues/104

If you do 

```
project plugin
++2.12.2
^^ 1.0.0-RC3
```

More details here: http://developer.lightbend.com/blog/2017-07-28-sbt-1-0-0-RC3-and-sbt-0-13-16/index.html#try-sbt-1-0-0-rc3

then it will cross-build for sbt 1.0.0 .  Right now, it won't compile because it has a dependency on scalajs, and scalajs isn't crossbuilt for 1.0.0.

Depends on scala-js: https://github.com/scala-js/scala-js/issues/2390