### PR TITLE
Cross publish all projects

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -5,11 +5,12 @@ val scalatest = "3.0.4"
 lazy val twirl = project
     .in(file("."))
     .enablePlugins(PlayRootProject)
+    .enablePlugins(CrossPerProjectPlugin)
     .settings(
       scalaVersion := scala210,
       crossScalaVersions := List(scalaVersion.value, scala211, scala212)
     )
-    .aggregate(apiJvm, apiJs, parser, compiler)
+    .aggregate(apiJvm, apiJs, parser, compiler, plugin)
 
 lazy val api = crossProject
     .in(file("api"))

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -2,3 +2,5 @@ addSbtPlugin("com.typesafe.play" % "interplay" % sys.props.get("interplay.versio
 
 // For the Cross Build
 addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.20")
+
+addSbtPlugin("com.eed3si9n" % "sbt-doge" % "0.1.5")


### PR DESCRIPTION
This aggregates the `plugin` project so that is is cross published when running `sbt release`.

## Reference

Follow up to #145.