### PR TITLE
newLine at end of @this(...) and @(...) are not part of content

### DIFF
--- a/parser/src/main/scala/play/twirl/parser/TwirlParser.scala
+++ b/parser/src/main/scala/play/twirl/parser/TwirlParser.scala
@@ -902,8 +902,13 @@ class TwirlParser(val shouldParseInclusiveDot: Boolean) {
       input.regress(1)
       val p = input.offset()
       val args = templateArgs()
-      if (args != null) Some(position(PosString(args), p))
-      else None
+      if (args != null) {
+        val result = position(PosString(args), p)
+        check("\n")
+        Some(result)
+      } else {
+        None
+      }
     } else None
   }
 

--- a/sbt-twirl/src/sbt-test/twirl/compile/src/test/scala/test/Test.scala
+++ b/sbt-twirl/src/sbt-test/twirl/compile/src/test/scala/test/Test.scala
@@ -7,7 +7,7 @@ object Test extends App {
     assert(template.body == expected, s"Found '$template' but expected '$expected'")
   }
 
-  test(a.b.html.c.render("world"), "\nHello, world.\n")
+  test(a.b.html.c.render("world"), "Hello, world.\n")
 
-  test(html.template.render("42"), "\nAnswer: 42\n")
+  test(html.template.render("42"), "Answer: 42\n")
 }

--- a/sbt-twirl/src/sbt-test/twirl/scalajs-compile/src/main/scala/Test.scala
+++ b/sbt-twirl/src/sbt-test/twirl/scalajs-compile/src/main/scala/Test.scala
@@ -6,7 +6,7 @@ object Test extends App {
     assert(template.body == expected, s"Found '$template' but expected '$expected'")
   }
 
-  test(a.b.html.c.render("world"), "\nHello, world.\n")
+  test(a.b.html.c.render("world"), "Hello, world.\n")
 
-  test(html.template.render("42"), "\nAnswer: 42\n")
+  test(html.template.render("42"), "Answer: 42\n")
 }


### PR DESCRIPTION
This is quite a simple fix and I am wondering why this wasn't addressed yet.

If you have a template that defines a constructor or takes arguments you will always have a newLine in front of your rendered content. People are complaining about this behaviour e.g [here](https://github.com/playframework/twirl/issues/141#issuecomment-329448988) and I have seen other comments where people complain about the newLine behaviour of various twirl  expressions. This PR fixes a (small) part of that complains.

E.g. given following template:
```
@(someVar:String)
This is my content
```
currently renders to the following two lines
```

This is my content
```

But actually it should be just one line, without the new line
```
This is my content
```
The same happens when you use `this(...)`

IMHO the newLine at the end of `this(...)` and `@()` should not be seens as part of the template. These two lines just define the constructor and the arguments for the render method, but have nothing to do with the content.

Eventually my fix will also remove a lot of newLines for many people because usually you template call other templates that call other templates ... etc. so you will end up with many ugly new lines no one needs or wants.

All my pr does is calling `check("\n")` after the argument lists which swallows a new line if there is one.