### PR TITLE
[Backport] scala-js 0.6.21 (#163)

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,6 +1,6 @@
 addSbtPlugin("com.typesafe.play" % "interplay" % sys.props.get("interplay.version").getOrElse("1.3.13"))
 
 // For the Cross Build
-addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.20")
+addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.21")
 
 addSbtPlugin("com.eed3si9n" % "sbt-doge" % "0.1.5")

--- a/sbt-twirl/src/sbt-test/twirl/scalajs-compile/project/plugins.sbt
+++ b/sbt-twirl/src/sbt-test/twirl/scalajs-compile/project/plugins.sbt
@@ -1,3 +1,3 @@
 addSbtPlugin("com.typesafe.sbt" % "sbt-twirl" % sys.props("project.version"))
 
-addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.19")
+addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.21")


### PR DESCRIPTION
Backports #163 to make sure the `master` and the `1.3.x` branch are equal after `1.3.14` was tagged on the `master` branch so for future releases off the `1.3.x` branch we have the same codebase.
See https://gitter.im/playframework/contributors?at=5a9006b053c1dbb743685217