### PR TITLE
Revert "Change content type for JavaScript to application/json (#159)"

### DIFF
--- a/api/shared/src/main/scala/play/twirl/api/Formats.scala
+++ b/api/shared/src/main/scala/play/twirl/api/Formats.scala
@@ -10,7 +10,7 @@ object MimeTypes {
   val TEXT       = "text/plain"
   val HTML       = "text/html"
   val XML        = "application/xml"
-  val JAVASCRIPT = "application/javascript"
+  val JAVASCRIPT = "text/javascript"
 }
 
 object Formats {


### PR DESCRIPTION
This reverts commit ae99b3b8b13d8835703a6ac4dc50c5f0a2cd2606.

It should not be part of 1.3.x branch as it breaks compatibility.