### PR TITLE
fix warning in build.sbt

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,5 @@
 import interplay.ScalaVersions._
+import sbtcrossproject.crossProject
 
 val scalatest = "3.0.5-M1"
 
@@ -17,7 +18,7 @@ lazy val twirl = project
     .settings(releaseCrossBuild := false)
     .aggregate(apiJvm, apiJs, parser, compiler, plugin)
 
-lazy val api = crossProject
+lazy val api = crossProject(JVMPlatform, JSPlatform)
     .in(file("api"))
     .enablePlugins(PlayLibrary, Playdoc)
     .settings(commonSettings: _*)

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -3,4 +3,6 @@ addSbtPlugin("com.typesafe.play" % "interplay" % sys.props.get("interplay.versio
 // For the Cross Build
 addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.23")
 
+addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject" % "0.5.0")
+
 addSbtPlugin("com.eed3si9n" % "sbt-doge" % "0.1.5")


### PR DESCRIPTION
https://travis-ci.org/playframework/twirl/builds/392847639#L1314

```
/home/travis/build/playframework/twirl/build.sbt:20: warning: method crossProjectFromBuilder in trait CrossProjectExtra is deprecated: The built-in cross-project feature of sbt-scalajs is deprecated. Use the separate sbt plugin sbt-crossproject instead: https://github.com/portable-scala/sbt-crossproject
lazy val api = crossProject
               ^
```