### PR TITLE
Added security info to template escaping

### DIFF
--- a/docs/manual/working/javaGuide/main/templates/JavaTemplates.md
+++ b/docs/manual/working/javaGuide/main/templates/JavaTemplates.md
@@ -242,7 +242,7 @@ You can put a comment on the first line to document your template into the Scala
 
 ## Escaping
 
-By default, dynamic content parts are escaped according to the template type’s (e.g. HTML or XML) rules. If you want to output a raw content fragment, wrap it in the template content type.
+By default, dynamic content parts are escaped according to the template type’s (e.g. HTML or XML) rules. If you want to output a raw content fragment, wrap it in the template content type. When using this feature, consider the security implications of outputting raw HTML if there is any possibility that the user can control the content. This technique is a common cause of Cross Site Scripting (XSS) vulnerabilities and is dangerous if not used with caution.
 
 For example to output raw HTML:
 

--- a/docs/manual/working/javaGuide/main/templates/JavaTemplates.md
+++ b/docs/manual/working/javaGuide/main/templates/JavaTemplates.md
@@ -242,7 +242,9 @@ You can put a comment on the first line to document your template into the Scala
 
 ## Escaping
 
-By default, dynamic content parts are escaped according to the template type’s (e.g. HTML or XML) rules. If you want to output a raw content fragment, wrap it in the template content type. When using this feature, consider the security implications of outputting raw HTML if there is any possibility that the user can control the content. This technique is a common cause of Cross Site Scripting (XSS) vulnerabilities and is dangerous if not used with caution.
+By default, dynamic content parts are escaped according to the template type’s (e.g. HTML or XML) rules. If you want to output a raw content fragment, wrap it in the template content type
+
+> **Note:** When using this feature, consider the security implications of outputting raw HTML if there is any possibility that the user can control the content. This technique is a common cause of Cross Site Scripting (XSS) vulnerabilities and is dangerous if not used with caution.
 
 For example to output raw HTML:
 

--- a/docs/manual/working/scalaGuide/main/templates/ScalaTemplates.md
+++ b/docs/manual/working/scalaGuide/main/templates/ScalaTemplates.md
@@ -158,7 +158,7 @@ You can put a comment on the first line to document your template into the Scala
 
 ## Escaping
 
-By default, dynamic content parts are escaped according to the template type’s (e.g. HTML or XML) rules. If you want to output a raw content fragment, wrap it in the template content type.
+By default, dynamic content parts are escaped according to the template type’s (e.g. HTML or XML) rules. If you want to output a raw content fragment, wrap it in the template content type. When using this feature, consider the security implications of outputting raw HTML if there is any possibility that the user can control the content. This technique is a common cause of Cross Site Scripting (XSS) vulnerabilities and is dangerous if not used with caution.
 
 For example to output raw HTML:
 
@@ -172,7 +172,7 @@ The template engine can be used as a [string interpolator](http://docs.scala-lan
 
 ## Displaying Scala types
 
-Twirl typically renders values of Scala types by calling `toString` method on them. However, if values are wrapped inside `Option` or collections (`Seq`, `Array`, `TraversableOnce`), Twirl first unwraps the values  and then calls `toString`. 
+Twirl typically renders values of Scala types by calling `toString` method on them. However, if values are wrapped inside `Option` or collections (`Seq`, `Array`, `TraversableOnce`), Twirl first unwraps the values  and then calls `toString`.
 
 For example,
 

--- a/docs/manual/working/scalaGuide/main/templates/ScalaTemplates.md
+++ b/docs/manual/working/scalaGuide/main/templates/ScalaTemplates.md
@@ -158,7 +158,9 @@ You can put a comment on the first line to document your template into the Scala
 
 ## Escaping
 
-By default, dynamic content parts are escaped according to the template type’s (e.g. HTML or XML) rules. If you want to output a raw content fragment, wrap it in the template content type. When using this feature, consider the security implications of outputting raw HTML if there is any possibility that the user can control the content. This technique is a common cause of Cross Site Scripting (XSS) vulnerabilities and is dangerous if not used with caution.
+By default, dynamic content parts are escaped according to the template type’s (e.g. HTML or XML) rules. If you want to output a raw content fragment, wrap it in the template content type.
+
+> **Note:** When using this feature, consider the security implications of outputting raw HTML if there is any possibility that the user can control the content. This technique is a common cause of Cross Site Scripting (XSS) vulnerabilities and is dangerous if not used with caution.
 
 For example to output raw HTML:
 


### PR DESCRIPTION
A very brief explanation of template escaping is given (with code sample), but there is currently no warning of the security implications of using this technique. Given the potential for harm, I think it would be helpful for developers to understand the risks in using this.

I've added a short description as a starting point for discussion and would be grateful to receive feedback on it. I considered including links to more detailed content on XSS but wasn't sure if that fits with the documentation guidelines for twirl. Happy to add some links if anyone thinks that would be beneficial.