### PR TITLE
Add Scala 2.130-M5 support

### DIFF
--- a/compiler/src/main/scala/play/twirl/compiler/TwirlCompiler.scala
+++ b/compiler/src/main/scala/play/twirl/compiler/TwirlCompiler.scala
@@ -505,7 +505,7 @@ package """ :+ packageName :+ """
         }
 
         val compiler = new Global(settings, new ConsoleReporter(settings) {
-          override def printMessage(pos: Position, msg: String) = ()
+          override def display(pos: Position, msg: String, severity: Severity): Unit = ()
         })
 
         // Everything must be done on the compiler thread, because the presentation compiler is a fussy piece of work.

--- a/compiler/src/test/scala/play/twirl/compiler/test/CompilerSpec.scala
+++ b/compiler/src/test/scala/play/twirl/compiler/test/CompilerSpec.scala
@@ -266,8 +266,11 @@ object Helper {
       }
 
       val compiler = new Global(settings, new ConsoleReporter(settings) {
-        override def printMessage(pos: Position, msg: String) = {
-          compileErrors.append(CompilationError(msg, pos.line, pos.point))
+        override def display(pos: Position, msg: String, severity: Severity): Unit = {
+          pos match {
+            case scala.reflect.internal.util.NoPosition => // do nothing
+            case _ => compileErrors.append(CompilationError(msg, pos.line, pos.point))
+          }
         }
       })
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,7 +1,7 @@
 addSbtPlugin("com.typesafe.play" % "interplay" % sys.props.get("interplay.version").getOrElse("2.0.3"))
 
 // For the Cross Build
-addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.24")
+addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.25")
 
 addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject" % "0.6.0")
 


### PR DESCRIPTION
This also maintains the builds for M3 and M4.

/cc @SethTisue 

## Reference

See a discussion about why we need to override `display` instead of `printMessage`: https://github.com/scalate/scalate/issues/199

