### PR TITLE
Correctly parse code block arguments

### DIFF
--- a/parser/src/main/scala/play/twirl/parser/TwirlParser.scala
+++ b/parser/src/main/scala/play/twirl/parser/TwirlParser.scala
@@ -492,7 +492,8 @@ class TwirlParser(val shouldParseInclusiveDot: Boolean) {
   def blockArgs(): PosString = {
     val p = input.offset()
     val result = anyUntil("=>", inclusive = true)
-    if (result.endsWith("=>") && !result.contains("\n"))
+    if (result.endsWith("=>") && !result.contains("\n") && !result.contains("{") && !result.contains("}") &&
+      (!result.contains("(") || (result.trim.startsWith("(") && result.stripSuffix("=>").trim.endsWith(")") && result.count(_ == '(') == 1)))
       position(PosString(result), p)
     else {
       input.regress(result.length())

--- a/parser/src/main/scala/play/twirl/parser/TwirlParser.scala
+++ b/parser/src/main/scala/play/twirl/parser/TwirlParser.scala
@@ -490,10 +490,13 @@ class TwirlParser(val shouldParseInclusiveDot: Boolean) {
   }
 
   def blockArgs(): PosString = {
+    def noCurlyBraces(result: String): Boolean = !result.contains("{") && !result.contains("}")
+    def noOpeningParenthesis(result: String): Boolean = !result.contains("(") ||
+      (result.trim.startsWith("(") && result.stripSuffix("=>").trim.endsWith(")") && result.count(_ == '(') == 1)
+
     val p = input.offset()
     val result = anyUntil("=>", inclusive = true)
-    if (result.endsWith("=>") && !result.contains("\n") && !result.contains("{") && !result.contains("}") &&
-      (!result.contains("(") || (result.trim.startsWith("(") && result.stripSuffix("=>").trim.endsWith(")") && result.count(_ == '(') == 1)))
+    if (result.endsWith("=>") && !result.contains("\n") && noCurlyBraces(result) && noOpeningParenthesis(result))
       position(PosString(result), p)
     else {
       input.regress(result.length())


### PR DESCRIPTION
When twirl detects a code block that starts with `{` and ends with `}` it tries to parse block arguments:
```
{ myCodeBlockArg =>
  blockBody
}
```
That code block parsing is also used for `if`, `else`, `for`,... blocks.

However:
Right now, parsing code block arguments in twirl is a buggy, "stupid" process:

https://github.com/playframework/twirl/blob/6dd88ad7eca2f90ffa6e91b42e43b1149586dcfb/parser/src/main/scala/play/twirl/parser/TwirlParser.scala#L494-L495

As you can see twirl just looks for a first `=>` in the *first* line of the code block body (that is of course also the line actually starting the code block via `{`).

But if you have a template like
```
@if(attrs!=null){@attrs.map{ v => @v._1 }}
```
that first `=>` in the *first* line of the code block obviously does not belong to the block arguments but to the `map` statement...  Twirl however just goes ahead, looks for the first `=>` and says that's the code block argument's end, which in our case would be `@attrs.map{ v =>`. Obviously that will end up in a compilation error.

The fix is easy:
We can just skip the code block arg if it contains a `{` or a `(`, meaning it is definitely not a code block arg (since neither an argument name nor an argument type are allowed to contain these signs). These signs however indicate the possible start of another statement to which the `=>` belongs to.
Plus we also skip if there is a `}` sign which actually closes the code block, meaning the `=>` was found outside of the code block already (like `@if(attrs!=null){blockbody}Some plain text with => outside the code block` where twirl would currently treat `blockbody}Some plain text with =>` as (incorrect) block arg).

Fixes #80