### PR TITLE
Match statement not allowed to have code block args

### DIFF
--- a/parser/src/main/scala/play/twirl/parser/TwirlParser.scala
+++ b/parser/src/main/scala/play/twirl/parser/TwirlParser.scala
@@ -504,12 +504,12 @@ class TwirlParser(val shouldParseInclusiveDot: Boolean) {
     }
   }
 
-  def block(): Block = {
+  def block(blockArgsAllowed: Boolean): Block = {
     var result: Block = null
     val p = input.offset()
     val ws = whitespaceNoBreak()
     if (check("{")) {
-      val blkArgs = Option(blockArgs())
+      val blkArgs = if(blockArgsAllowed) Option(blockArgs()) else None
       val mixeds = several[ListBuffer[TemplateTree], ListBuffer[ListBuffer[TemplateTree]]] { () => mixed() }
       accept("}")
       // TODO - not use flatten here (if it's a performance problem)
@@ -529,7 +529,7 @@ class TwirlParser(val shouldParseInclusiveDot: Boolean) {
     val p = input.offset()
     if (check("case ")) {
       val pattern = position(Simple("case " + anyUntil("=>", inclusive = true)), p)
-      val blk = block()
+      val blk = block(blockArgsAllowed = true)
       if (blk != null) {
         result = ScalaExp(ListBuffer(pattern, blk))
         whitespace()
@@ -560,7 +560,7 @@ class TwirlParser(val shouldParseInclusiveDot: Boolean) {
       val ws = whitespaceNoBreak()
       if (check("match")) {
         val m = position(Simple(ws + "match"), mpos)
-        val blk = block()
+        val blk = block(blockArgsAllowed = false)
         if (blk != null) {
           exprs.append(m)
           exprs.append(blk)
@@ -582,7 +582,7 @@ class TwirlParser(val shouldParseInclusiveDot: Boolean) {
     if (check("@for")) {
       val parens = parentheses()
       if (parens != null) {
-        val blk = block()
+        val blk = block(blockArgsAllowed = true)
         if (blk != null) {
           result = Display(ScalaExp(ListBuffer(position(Simple("for" + parens + " yield "), p+1), blk))) // don't include pos of @
         }
@@ -631,7 +631,7 @@ class TwirlParser(val shouldParseInclusiveDot: Boolean) {
       val pos = input.offset()
       val code = methodCall()
       if (code != null) {
-        val parts = several[ScalaExpPart, ListBuffer[ScalaExpPart]] { () => expressionPart() }
+        val parts = several[ScalaExpPart, ListBuffer[ScalaExpPart]] { () => expressionPart(blockArgsAllowed = true) }
         parts.prepend(position(Simple(code), pos))
         result = Display(ScalaExp(parts))
       } else input.regressTo(pos - 1) // don't consume the @
@@ -650,7 +650,7 @@ class TwirlParser(val shouldParseInclusiveDot: Boolean) {
     } else null
   }
 
-  def expressionPart(): ScalaExpPart = {
+  def expressionPart(blockArgsAllowed: Boolean): ScalaExpPart = {
     def simpleParens() = {
       val p = input.offset()
       val parens = parentheses()
@@ -667,7 +667,7 @@ class TwirlParser(val shouldParseInclusiveDot: Boolean) {
     }
 
     chainedMethods() match {
-      case null => block() match {
+      case null => block(blockArgsAllowed) match {
         case null => wsThenScalaBlockChained() match {
           case null => elseIfCall() match {
             case null => elseCall() match {

--- a/parser/src/test/scala/play/twirl/parser/test/ParserSpec.scala
+++ b/parser/src/test/scala/play/twirl/parser/test/ParserSpec.scala
@@ -141,6 +141,25 @@ class ParserSpec extends WordSpec with MustMatchers with Inside {
         val outsideIf = tmpl.content(1).asInstanceOf[Plain]
         outsideIf.text mustBe "Some plain text with => inside"
       }
+
+      "match statement not allowed to have block arguments" in {
+        val tmpl = parseTemplateString("""@fooVariable match { case x: String => { Nice string } case _ => { Not a nice string } }""") // " case x: String =>" should not be handled as block args of the match block
+        val matchExpressions = tmpl.content(0).asInstanceOf[Display].exp.parts
+        matchExpressions.head must be (Simple("fooVariable"))
+        matchExpressions(1) must be (Simple(" match"))
+
+        val matchBlock = matchExpressions(2).asInstanceOf[Block].content
+
+        val firstCaseBlock = matchBlock.head.asInstanceOf[ScalaExp].parts
+        firstCaseBlock.head must be (Simple("case x: String =>"))
+        val firstCaseBlockBody = firstCaseBlock(1).asInstanceOf[Block]
+        firstCaseBlockBody.content(1).asInstanceOf[Plain].text mustBe "Nice string "
+
+        val secondCaseBlock = matchBlock(1).asInstanceOf[ScalaExp].parts
+        secondCaseBlock.head must be (Simple("case _ =>"))
+        val secondCaseBlockBody = secondCaseBlock(1).asInstanceOf[Block]
+        secondCaseBlockBody.content(1).asInstanceOf[Plain].text mustBe "Not a nice string "
+      }
     }
 
     "handle string literals within parentheses" when {


### PR DESCRIPTION
The code block of a `match` statement never has block arguments, according to the [Scala specification](https://www.scala-lang.org/files/archive/spec/2.12/13-syntax-summary.html):

```
Expr1             ::=  ... | PostfixExpr ‘match’ ‘{’ CaseClauses ‘}’
...
CaseClauses       ::=  CaseClause { CaseClause }
...
CaseClause        ::=  ‘case’ Pattern [Guard] ‘=>’ Block
```

This finally allows us to have `match ... case` statements on the same line within twirl templates :wink: