### PR TITLE
Remove old scala 2.13 versions

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -4,7 +4,7 @@ import org.scalajs.jsenv.nodejs.NodeJSEnv
 
 val commonSettings = Seq(
   scalaVersion := scala210,
-  crossScalaVersions := Seq(scalaVersion.value, scala211, scala212, scala213)
+  crossScalaVersions := Seq(scalaVersion.value, scala211, scala212, scala213, "2.13.0-M3")
 )
 
 lazy val twirl = project

--- a/build.sbt
+++ b/build.sbt
@@ -4,7 +4,7 @@ import org.scalajs.jsenv.nodejs.NodeJSEnv
 
 val commonSettings = Seq(
   scalaVersion := scala210,
-  crossScalaVersions := Seq(scalaVersion.value, scala211, scala212, "2.13.0-M3", "2.13.0-M4", "2.13.0-M5")
+  crossScalaVersions := Seq(scalaVersion.value, scala211, scala212, scala213)
 )
 
 lazy val twirl = project

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,4 +1,4 @@
-addSbtPlugin("com.typesafe.play" % "interplay" % sys.props.get("interplay.version").getOrElse("2.0.3"))
+addSbtPlugin("com.typesafe.play" % "interplay" % sys.props.get("interplay.version").getOrElse("2.0.4"))
 
 // For the Cross Build
 addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.25")


### PR DESCRIPTION
This PR updates Twirl to use interplay 2.0.4 and it removes old Scala 2.13 versions. 

We are not building Play for any of the Scala 2.13 versions so in principle there is no reason for keeping them around. 

I'm keeping 2.13.0-M5 though. 