### PR TITLE
[1.4] Scala 2.13.0-RC1 (#213)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,7 @@ scala:
   - 2.12.8
   - 2.11.12
   - 2.10.7
+  - 2.13.0-RC1
 
 script:
   - sbt "+++ $TRAVIS_SCALA_VERSION test"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,53 +1,35 @@
 language: scala
-
-before_install:
-  - curl -sL https://github.com/shyiko/jabba/raw/master/install.sh | bash && . ~/.jabba/jabba.sh
-
-install:
-  - $JABBA_HOME/bin/jabba install $TRAVIS_JDK
-  - unset _JAVA_OPTIONS
-  - export JAVA_HOME="$JABBA_HOME/jdk/$TRAVIS_JDK" && export PATH="$JAVA_HOME/bin:$PATH" && java -Xmx32m -version
-
-env:
-  global:
-    - JABBA_HOME=$HOME/.jabba
-  matrix:
-    - TRAVIS_JDK=adopt@1.8.192-12
-    - TRAVIS_JDK=adopt@1.11.0-1
-
-matrix:
-  fast_finish: true
-  allow_failures:
-    # Java 11 is still not fully supported. It is good that we are already
-    # testing Twirl using it to better discover possible problems but we
-    # can allow failures here too.
-    - env: TRAVIS_JDK=adopt@1.11.0-1
-
 scala:
-  - 2.12.8
-  - 2.11.12
   - 2.10.7
+  - 2.11.12
+  - 2.12.8
   - 2.13.0-RC1
 
+env:
+  matrix:
+    - TRAVIS_JDK=adopt@1.8.202-08
+    - TRAVIS_JDK=adopt@1.11.0-2
+
+before_install: curl -Ls https://git.io/jabba | bash && . ~/.jabba/jabba.sh
+install: jabba install "$TRAVIS_JDK" && jabba use "$_" && java -Xmx32m -version
 script:
-  - sbt "+++ $TRAVIS_SCALA_VERSION test"
-  - sbt +publishLocal
-  - sbt +mimaReportBinaryIssues
-  - sbt 'project plugin' test
-  - sbt 'project plugin' scripted
-  - cd docs && sbt test validateDocs
+  - sbt "++ $TRAVIS_SCALA_VERSION test"  || travis_terminate 1
+  - sbt +publishLocal                    || travis_terminate 1
+  - sbt plugin/test                      || travis_terminate 1
+  - sbt plugin/scripted                  || travis_terminate 1
+  - cd docs && sbt test validateDocs     || travis_terminate 1
 
 cache:
   directories:
-  - "$HOME/.ivy2/cache"
-  - "$HOME/.sbt/boot/"
-  - "$HOME/.jabba/jdk"
+    - "$HOME/.ivy2/cache"
+    - "$HOME/.jabba/jdk"
+    - "$HOME/.sbt"
 
 before_cache:
   - rm -rf $HOME/.ivy2/cache/com.typesafe.play/twirl*
   - rm -rf $HOME/.ivy2/cache/scala_*/sbt_*/com.typesafe.sbt/sbt-twirl
   - find $HOME/.ivy2 -name "ivydata-*.properties" -delete
-  - find $HOME/.sbt -name "*.lock" -delete
+  - find $HOME/.sbt  -name "*.lock"               -delete
 
 notifications:
   webhooks:

--- a/build.sbt
+++ b/build.sbt
@@ -5,12 +5,13 @@ import org.scalajs.jsenv.nodejs.NodeJSEnv
 // Binary compatibility is this version
 val previousVersion = "1.4.0"
 
-val binaryCompatibilitySettings = Seq(
-  mimaPreviousArtifacts := Set(organization.value % s"${moduleName.value}_${scalaBinaryVersion.value}" % previousVersion)
-)
+def binaryCompatibilitySettings(org: String, moduleName: String, scalaBinVersion: String): Set[ModuleID] = {
+  if (scalaBinVersion.equals(scala213)) Set.empty
+  else Set(org % s"${moduleName}_${scalaBinVersion}" % previousVersion)
+}
 
 val commonSettings = Seq(
-  scalaVersion := scala210,
+  scalaVersion := scala212,
   crossScalaVersions := Seq(scala210, "2.11.12", scala212, scala213)
 )
 
@@ -34,7 +35,7 @@ lazy val api = crossProject(JVMPlatform, JSPlatform)
     .in(file("api"))
     .enablePlugins(PlayLibrary, Playdoc)
     .settings(commonSettings: _*)
-    .settings(binaryCompatibilitySettings: _*)
+    .settings(mimaPreviousArtifacts := binaryCompatibilitySettings(organization.value, moduleName.value, scalaBinaryVersion.value))
     .settings(
       name := "twirl-api",
       jsEnv := nodeJs,
@@ -49,7 +50,7 @@ lazy val parser = project
     .in(file("parser"))
     .enablePlugins(PlayLibrary)
     .settings(commonSettings: _*)
-    .settings(binaryCompatibilitySettings: _*)
+    .settings(mimaPreviousArtifacts := binaryCompatibilitySettings(organization.value, moduleName.value, scalaBinaryVersion.value))
     .settings(
       name := "twirl-parser",
       libraryDependencies ++= scalaParserCombinators(scalaVersion.value),
@@ -62,7 +63,7 @@ lazy val compiler = project
     .enablePlugins(PlayLibrary)
     .dependsOn(apiJvm, parser % "compile;test->test")
     .settings(commonSettings: _*)
-    .settings(binaryCompatibilitySettings: _*)
+    .settings(mimaPreviousArtifacts := binaryCompatibilitySettings(organization.value, moduleName.value, scalaBinaryVersion.value))
     .settings(
       name := "twirl-compiler",
       libraryDependencies += scalaCompiler(scalaVersion.value),

--- a/build.sbt
+++ b/build.sbt
@@ -18,8 +18,8 @@ val commonSettings = Seq(
 lazy val twirl = project
     .in(file("."))
     .enablePlugins(PlayRootProject)
-    .enablePlugins(CrossPerProjectPlugin)
     .settings(commonSettings: _*)
+    .settings(crossScalaVersions := Nil) // workaround so + uses project-defined variants
     .settings(releaseCrossBuild := false)
     .aggregate(apiJvm, apiJs, parser, compiler, plugin)
 
@@ -34,6 +34,7 @@ lazy val nodeJs = {
 lazy val api = crossProject(JVMPlatform, JSPlatform)
     .in(file("api"))
     .enablePlugins(PlayLibrary, Playdoc)
+    .configs(Docs)
     .settings(commonSettings: _*)
     .settings(mimaPreviousArtifacts := binaryCompatibilitySettings(organization.value, moduleName.value, scalaBinaryVersion.value))
     .settings(
@@ -73,7 +74,7 @@ lazy val compiler = project
 
 lazy val plugin = project
     .in(file("sbt-twirl"))
-    .enablePlugins(PlaySbtPlugin)
+    .enablePlugins(PlaySbtPlugin, SbtPlugin)
     .dependsOn(compiler)
     .settings(
       name := "sbt-twirl",

--- a/build.sbt
+++ b/build.sbt
@@ -11,7 +11,7 @@ val binaryCompatibilitySettings = Seq(
 
 val commonSettings = Seq(
   scalaVersion := scala210,
-  crossScalaVersions := Seq(scalaVersion.value, scala211, scala212, scala213, "2.13.0-M3")
+  crossScalaVersions := Seq(scala210, "2.11.12", scala212, scala213)
 )
 
 lazy val twirl = project
@@ -77,6 +77,7 @@ lazy val plugin = project
     .settings(
       name := "sbt-twirl",
       organization := "com.typesafe.sbt",
+      scalaVersion := scala212,
       libraryDependencies += "org.scalatest" %%% "scalatest" % scalatest(scalaVersion.value) % "test",
       resourceGenerators in Compile += generateVersionFile.taskValue,
       scriptedDependencies := {
@@ -108,27 +109,22 @@ def generateVersionFile = Def.task {
 // Dependencies
 
 def scalatest(scalaV: String): String = scalaV match {
-  case "2.13.0-M3" => "3.0.5-M1"
-  case "2.13.0-M4" => "3.0.6-SNAP2"
-  case _ => "3.0.6-SNAP4"
+  case _ => "3.0.8-RC2"
 }
 
 def scalaCompiler(version: String) = "org.scala-lang" % "scala-compiler" % version
 
 def scalaParserCombinators(scalaVersion: String): Seq[ModuleID] = scalaVersion match {
   case interplay.ScalaVersions.scala210 => Seq.empty
-  case "2.13.0-M3" => Seq(
-    "org.scala-lang.modules" %% "scala-parser-combinators" % "1.1.0" % "optional"
-  )
   case _ => Seq(
-    "org.scala-lang.modules" %% "scala-parser-combinators" % "1.1.1" % "optional"
+    "org.scala-lang.modules" %% "scala-parser-combinators" % "1.1.2" % "optional"
   )
 }
 
 def scalaXml = Def.setting {
   CrossVersion.partialVersion(scalaVersion.value) match {
     case Some((x, y)) if x > 2 || (x == 2 && y >= 11) =>
-      Seq("org.scala-lang.modules" %%% "scala-xml" % "1.1.0")
+      Seq("org.scala-lang.modules" %%% "scala-xml" % "1.2.0")
     case _ =>
       Seq.empty
   }

--- a/docs/build.sbt
+++ b/docs/build.sbt
@@ -1,8 +1,9 @@
 lazy val docs = project
   .in(file("."))
   .enablePlugins(PlayDocsPlugin)
+  .configs(Configuration.of("Docs", "docs"))
   .settings(
-    scalaVersion := "2.11.12",
+    scalaVersion := "2.12.8",
     // use special snapshot play version for now
     resolvers ++= DefaultOptions.resolvers(snapshot = true),
     resolvers += Resolver.typesafeRepo("releases"),

--- a/docs/project/build.properties
+++ b/docs/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.18
+sbt.version=1.2.8

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.18
+sbt.version=1.2.8

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -5,6 +5,4 @@ addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.27")
 
 addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject" % "0.6.0")
 
-addSbtPlugin("com.eed3si9n" % "sbt-doge" % "0.1.5")
-
 addSbtPlugin("com.typesafe" % "sbt-mima-plugin" % "0.3.0")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,7 +1,7 @@
-addSbtPlugin("com.typesafe.play" % "interplay" % sys.props.get("interplay.version").getOrElse("2.0.5"))
+addSbtPlugin("com.typesafe.play" % "interplay" % sys.props.get("interplay.version").getOrElse("2.0.6"))
 
 // For the Cross Build
-addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.25")
+addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.27")
 
 addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject" % "0.6.0")
 

--- a/sbt-twirl/src/sbt-test/twirl/scalajs-compile/project/plugins.sbt
+++ b/sbt-twirl/src/sbt-test/twirl/scalajs-compile/project/plugins.sbt
@@ -1,3 +1,3 @@
 addSbtPlugin("com.typesafe.sbt" % "sbt-twirl" % sys.props("project.version"))
 
-addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.24")
+addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.27")


### PR DESCRIPTION
Backport won't be clean since here we are removing Scala 2.11 and we should keep it in branch 1.4.x.

(cherry picked from commit d81deb6a04fa96d1bd252640c937f7175dc30f3f)