### PR TITLE
Template parameters can be deprecated

### DIFF
--- a/parser/src/main/scala/play/twirl/parser/TreeNodes.scala
+++ b/parser/src/main/scala/play/twirl/parser/TreeNodes.scala
@@ -15,6 +15,7 @@ object TreeNodes {
       name: PosString,
       constructor: Option[Constructor],
       comment: Option[Comment],
+      templateFunctionName: Option[PosString],
       params: PosString,
       topImports: collection.Seq[Simple],
       imports: collection.Seq[Simple],


### PR DESCRIPTION
Right now it's not possible to deprecate the generated `render`, `apply` and `f` methods. So we have no choice of breaking the API as soon the args passed via `@(...)` change. This bit as before and bites us again in https://github.com/playframework/playframework/issues/9447.

Therefore I propose to once and for all fix this problem by adding a `@deprecatedParams` tag, which you can use to overload the `render` and `apply` method with deprecated ones. There is just one small problem: We can not overload the `f` method, because they just differ in the return type... Therefore to make this work, we need to rename that `f` method. Therefore I will add a `@templateFunctionName("...")` tag which just sets the name of the `f` method.

And this is how I suggest it will look like. Given you have the following template:

```html
@*********************
 * This is a comment *
 *********************@
@import com.typsafe....
@this()
@(one: Int, two: Int)
...Template content here...
```

And you want to deprecate the arguments and replace them with String equivalents:

```html
@*********************
 * This is a comment *
 *********************@
@import com.typsafe....
@this()
@templateFunctionName("fn")
@deprecatedParams("2.8.0", "f")(one: Int, two: Int) = @{
   val newOne = one + 1
   val newTwo = two - 1
   apply(newOne.toString, newTwo.toString)
}
@(one: String, two: String)
...Template content here...
```

We pass the `@deprecatedParams` the version since when we want the methods to be deprecate (to generate `@deprecated(since="2.8.0")`) and the name of the `f` function which should be deprecated (here it's `f` because that is the default name). Finally we pass the arguments for the deprecated `render`, `apply` and return type of `f`.

Now in the next version we can just remove the `@deprecatedParams` tag, but keep the `@templateFunctionName` (because that's the method's name now):
```html
@*********************
 * This is a comment *
 *********************@
@import com.typsafe....
@this()
@templateFunctionName("fn")
@(one: String, two: String)
...Template content here...
```

Now in case we want to again deprecate these arguments you can now just remove the `@templateFunctionName` (resulting in the generating the method `f` with its default name), but tell `@deprecatedParams("2.10.0", "fn")(...` that the method to deprecate is `fn`.

**TODO's:**

- [x] `@templateFunctionName("...")`
- [ ] Docs for `@templateFunctionName`
- [ ] `@deprecatedParams`
- [ ] Docs for `@deprecatedParams` 
- [ ] Tests