### PR TITLE
Fix for running with GraalVM

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -51,6 +51,15 @@ lazy val api = crossProject(JVMPlatform, JSPlatform)
     mimaSettings,
     name := "twirl-api",
     jsEnv := nodeJs,
+    // hack for GraalVM, see: https://github.com/scala-js/scala-js/issues/3673
+    // and https://github.com/playframework/twirl/pull/339
+    testFrameworks := List(
+      new TestFramework(
+        "org.scalatest.tools.Framework",
+        "org.scalatest.tools.ScalaTestFramework",
+        "com.novocode.junit.JUnitFramework"
+      )
+    ),
     libraryDependencies += "org.scala-lang.modules" %%% "scala-xml" % ScalaXmlVersion,
     libraryDependencies += "org.scalatest"          %%% "scalatest" % ScalaTestVersion % "test",
   )

--- a/build.sbt
+++ b/build.sbt
@@ -56,8 +56,7 @@ lazy val api = crossProject(JVMPlatform, JSPlatform)
     testFrameworks := List(
       new TestFramework(
         "org.scalatest.tools.Framework",
-        "org.scalatest.tools.ScalaTestFramework",
-        "com.novocode.junit.JUnitFramework"
+        "org.scalatest.tools.ScalaTestFramework"
       )
     ),
     libraryDependencies += "org.scala-lang.modules" %%% "scala-xml" % ScalaXmlVersion,


### PR DESCRIPTION
Not such an important fix, but when running with GraalVM, tests will fail with 

```scala
[info] Passed: Total 35, Failed 0, Errors 0, Passed 35
[error] stack trace is suppressed; run last apiJS / Test / loadedTestFrameworks for the full output
[error] (apiJS / Test / loadedTestFrameworks) org.scalajs.testcommon.RPCCore$RPCException: scala.scalajs.js.JavaScriptException: TypeError: Access to host class org.scalacheck.ScalaCheckFramework is not allowed or does not exist.
```

See https://github.com/scala-js/scala-js/issues/3673

I was hit by this one, not pleasant. 