### PR TITLE
Lock ScalaJs to 1.0

### DIFF
--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -1,0 +1,11 @@
+pullRequests.frequency = "@weekly"
+
+updates.pin  = [
+  // "It is not forward binary compatible with 1.0.x: libraries compiled with 1.1.0 cannot be used with 1.0.x."
+  // https://users.scala-lang.org/t/announcing-scala-js-1-1-0/6053/3?u=sjrd
+  { groupId = "org.scala-js", artifactId= "sbt-scalajs", version = "1.0." }
+  // Scalatest 3.2.x pulls in ScalaJs 1.1
+  { groupId = "org.scalatest", artifactId = "scalatest", version = "3.1." }
+]
+
+commits.message = "${artifactName} ${nextVersion} (was ${currentVersion})"


### PR DESCRIPTION
Twirl doesn't work with ScalaJs 1.0, yet (see #319) and if there is no interest it should drop ScalaJs support.

This prevents Scala Steward from suggesting ScalaJs after 1.0 (and ScalaTest past 3.2 wich would hinder ScalaJs 1.0).

See https://github.com/playframework/play-json/pull/498