### PR TITLE
version bumps and cleanups

### DIFF
--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -1,11 +1,2 @@
 pullRequests.frequency = "@weekly"
-
-updates.pin  = [
-  // "It is not forward binary compatible with 1.0.x: libraries compiled with 1.1.0 cannot be used with 1.0.x."
-  // https://users.scala-lang.org/t/announcing-scala-js-1-1-0/6053/3?u=sjrd
-  { groupId = "org.scala-js", artifactId= "sbt-scalajs", version = "1.0." }
-  // Scalatest 3.2.x pulls in ScalaJs 1.1
-  { groupId = "org.scalatest", artifactId = "scalatest", version = "3.1." }
-]
-
 commits.message = "${artifactName} ${nextVersion} (was ${currentVersion})"

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ jobs:
     - name: "Run tests with Scala 2.12 and AdoptOpenJDK 11"
       script: scripts/test-code.sh
       env:
-        - TRAVIS_SCALA_VERSION=2.12.12
+        - TRAVIS_SCALA_VERSION=2.12.13
         - TRAVIS_JDK=11
 
     - name: "Run tests with Scala 2.13 and AdoptOpenJDK 11"
@@ -39,7 +39,7 @@ jobs:
     - name: "Run tests with Scala 2.12 and AdoptOpenJDK 8"
       script: scripts/test-code.sh
       env:
-        - TRAVIS_SCALA_VERSION=2.12.12
+        - TRAVIS_SCALA_VERSION=2.12.13
         - TRAVIS_JDK=8
 
     - name: "Run tests with Scala 2.13 and AdoptOpenJDK 8"

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ git:
   depth: false # Avoid sbt-dynver not seeing the tag
 
 env:
-  matrix: 
+  matrix:
     - TRAVIS_JDK=11
 
   global:
@@ -30,25 +30,25 @@ jobs:
         - TRAVIS_SCALA_VERSION=2.12.12
         - TRAVIS_JDK=11
 
-    - name: "Run tests with Scala 2.13 and AdoptOpenJDK 11" 
+    - name: "Run tests with Scala 2.13 and AdoptOpenJDK 11"
       script: scripts/test-code.sh
-      env: 
+      env:
         - TRAVIS_SCALA_VERSION=2.13.4
-        - TRAVIS_JDK=11 
+        - TRAVIS_JDK=11
 
-    - name: "Run tests with Scala 2.12 and AdoptOpenJDK 8" 
+    - name: "Run tests with Scala 2.12 and AdoptOpenJDK 8"
       script: scripts/test-code.sh
-      env: 
+      env:
         - TRAVIS_SCALA_VERSION=2.12.12
-        - TRAVIS_JDK=8  
+        - TRAVIS_JDK=8
 
-    - name: "Run tests with Scala 2.13 and AdoptOpenJDK 8" 
+    - name: "Run tests with Scala 2.13 and AdoptOpenJDK 8"
       script: scripts/test-code.sh
-      env: 
+      env:
         - TRAVIS_SCALA_VERSION=2.13.4
-        - TRAVIS_JDK=8  
-        
-    - stage: docs  
+        - TRAVIS_JDK=8
+
+    - stage: docs
       script: scripts/validate-docs.sh
       name: "Validate documentation"
 
@@ -83,7 +83,7 @@ notifications:
     on_failure: always
   slack:
     secure: lrBEBp00Fwr3T72GXK+eOaQVNy34QT+OBcJanr/WCVoD3kgt+L5hkEZ3iS9B7pDd26vMBcUGBb5kM8Z5QGo48gvbLUFgRtaTU00EBoTXbUPDIqlaMkuxdF+TN7GgS7yZKnKIInj54e7o1QaJ4R/I/Atw81kUJr0PNzMU0hfg6VU=
-    
+
 # safelist
 branches:
   only:

--- a/build.sbt
+++ b/build.sbt
@@ -99,15 +99,19 @@ lazy val plugin = project
     scalaVersion := Scala212,
     libraryDependencies += "org.scalatest" %%% "scalatest" % ScalaTestVersion % Test,
     Compile / resourceGenerators += generateVersionFile.taskValue,
+    // both `locally`s are to work around sbt/sbt#6161
     scriptedDependencies := {
-      scriptedDependencies.value
-      publishLocal
-        .all(
-          ScopeFilter(
-            inDependencies(compiler)
+      locally { val _ = scriptedDependencies.value }
+      locally {
+        val _ = publishLocal
+          .all(
+            ScopeFilter(
+              inDependencies(compiler)
+            )
           )
-        )
-        .value
+          .value
+      }
+      ()
     },
     mimaFailOnNoPrevious := false,
   )

--- a/build.sbt
+++ b/build.sbt
@@ -5,7 +5,7 @@ import org.scalajs.jsenv.nodejs.NodeJSEnv
 // Binary compatibility is this version
 val previousVersion: Option[String] = Some("1.5.0")
 
-val ScalaTestVersion              = "3.1.4"
+val ScalaTestVersion              = "3.2.3"
 val ScalaXmlVersion               = "1.3.0"
 val ScalaParserCombinatorsVersion = "1.1.2"
 

--- a/build.sbt
+++ b/build.sbt
@@ -14,7 +14,7 @@ val mimaSettings = Seq(
 )
 
 // Customise sbt-dynver's behaviour to make it work with tags which aren't v-prefixed
-dynverTagPrefix in ThisBuild := ""
+ThisBuild / dynverTagPrefix := ""
 
 // Sanity-check: assert that version comes from a tag (e.g. not a too-shallow clone)
 // https://github.com/dwijnand/sbt-dynver/#sanity-checking-the-version
@@ -60,7 +60,7 @@ lazy val api = crossProject(JVMPlatform, JSPlatform)
       )
     ),
     libraryDependencies += "org.scala-lang.modules" %%% "scala-xml" % ScalaXmlVersion,
-    libraryDependencies += "org.scalatest"          %%% "scalatest" % ScalaTestVersion % "test",
+    libraryDependencies += "org.scalatest"          %%% "scalatest" % ScalaTestVersion % Test,
   )
 
 lazy val apiJvm = api.jvm
@@ -72,9 +72,9 @@ lazy val parser = project
   .settings(
     mimaSettings,
     name := "twirl-parser",
-    libraryDependencies += "org.scala-lang.modules" %% "scala-parser-combinators" % ScalaParserCombinatorsVersion % "optional",
-    libraryDependencies += "com.novocode"            % "junit-interface"          % "0.11"                        % "test",
-    libraryDependencies += "org.scalatest"         %%% "scalatest"                % ScalaTestVersion              % "test",
+    libraryDependencies += "org.scala-lang.modules" %% "scala-parser-combinators" % ScalaParserCombinatorsVersion % Optional,
+    libraryDependencies += "com.novocode"            % "junit-interface"          % "0.11"                        % Test,
+    libraryDependencies += "org.scalatest"         %%% "scalatest"                % ScalaTestVersion              % Test,
   )
 
 lazy val compiler = project
@@ -86,7 +86,7 @@ lazy val compiler = project
     name := "twirl-compiler",
     libraryDependencies += "org.scala-lang"          % "scala-compiler"           % scalaVersion.value,
     libraryDependencies += "org.scala-lang.modules" %% "scala-parser-combinators" % ScalaParserCombinatorsVersion % "optional",
-    fork in run := true,
+    run / fork := true,
   )
 
 lazy val plugin = project
@@ -97,8 +97,8 @@ lazy val plugin = project
     name := "sbt-twirl",
     organization := "com.typesafe.sbt",
     scalaVersion := Scala212,
-    libraryDependencies += "org.scalatest" %%% "scalatest" % ScalaTestVersion % "test",
-    resourceGenerators in Compile += generateVersionFile.taskValue,
+    libraryDependencies += "org.scalatest" %%% "scalatest" % ScalaTestVersion % Test,
+    Compile / resourceGenerators += generateVersionFile.taskValue,
     scriptedDependencies := {
       scriptedDependencies.value
       publishLocal
@@ -115,8 +115,8 @@ lazy val plugin = project
 // Version file
 def generateVersionFile =
   Def.task {
-    val version = (Keys.version in apiJvm).value
-    val file    = (resourceManaged in Compile).value / "twirl.version.properties"
+    val version = (apiJvm / Keys.version).value
+    val file    = (Compile / resourceManaged).value / "twirl.version.properties"
     val content = s"twirl.api.version=$version"
     IO.write(file, content)
     Seq(file)

--- a/docs/build.sbt
+++ b/docs/build.sbt
@@ -29,9 +29,9 @@ lazy val docs = project
 // twirl settings.
 def overrideTwirlSettings: Seq[Setting[_]] =
   Seq(
-    sourceGenerators in Test := Nil
+    Test / sourceGenerators := Nil
   ) ++ inConfig(Test)(SbtTwirl.twirlSettings) ++ SbtTwirl.defaultSettings ++ SbtTwirl.positionSettings ++ Seq(
-    sourceDirectories in (Test, TwirlKeys.compileTemplates) ++=
+    Test / TwirlKeys.compileTemplates / sourceDirectories ++=
       (PlayDocsKeys.javaManualSourceDirectories.value ++ PlayDocsKeys.scalaManualSourceDirectories.value)
   )
 

--- a/docs/build.sbt
+++ b/docs/build.sbt
@@ -3,7 +3,7 @@ lazy val docs = project
   .enablePlugins(PlayDocsPlugin)
   .configs(Configuration.of("Docs", "docs"))
   .settings(
-    scalaVersion := "2.12.12",
+    scalaVersion := "2.12.13",
     // use special snapshot play version for now
     resolvers ++= DefaultOptions.resolvers(snapshot = true),
     resolvers += Resolver.typesafeRepo("releases"),

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -3,7 +3,7 @@ import sbt._
 
 object Dependencies {
 
-  val Scala212      = "2.12.12"
+  val Scala212      = "2.12.13"
   val Scala213      = "2.13.4"
   val ScalaVersions = Seq(Scala212, Scala213)
 

--- a/project/Playdoc.scala
+++ b/project/Playdoc.scala
@@ -17,16 +17,16 @@ object Playdoc extends AutoPlugin {
   override def trigger = noTrigger
 
   override def projectSettings =
-    Defaults.packageTaskSettings(playdocPackage, mappings in playdocPackage) ++
+    Defaults.packageTaskSettings(playdocPackage, playdocPackage / mappings) ++
       Seq(
-        playdocDirectory := (baseDirectory in ThisBuild).value / "docs" / "manual",
-        mappings in playdocPackage := {
+        playdocDirectory := (ThisBuild / baseDirectory).value / "docs" / "manual",
+        playdocPackage / mappings := {
           val base: File = playdocDirectory.value
           base.allPaths.pair(IO.relativize(base.getParentFile(), _))
         },
-        artifactClassifier in playdocPackage := Some("playdoc"),
-        artifact in playdocPackage ~= { _.withConfigurations(Vector(Docs)) }
+        playdocPackage / artifactClassifier := Some("playdoc"),
+        playdocPackage / artifact ~= { _.withConfigurations(Vector(Docs)) }
       ) ++
-      addArtifact(artifact in playdocPackage, playdocPackage)
+      addArtifact(playdocPackage / artifact, playdocPackage)
 
 }

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,7 +1,7 @@
 addSbtPlugin("org.foundweekends" % "sbt-bintray" % "0.6.1")
 
 // For the Cross Build
-addSbtPlugin("org.scala-js" % "sbt-scalajs" % "1.4.0")
+addSbtPlugin("org.scala-js" % "sbt-scalajs" % "1.5.0")
 
 addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject" % "1.0.0")
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,7 +1,7 @@
 addSbtPlugin("org.foundweekends" % "sbt-bintray" % "0.6.1")
 
 // For the Cross Build
-addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.33")
+addSbtPlugin("org.scala-js" % "sbt-scalajs" % "1.4.0")
 
 addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject" % "1.0.0")
 

--- a/sbt-twirl/src/main/scala/play/twirl/sbt/SbtTwirl.scala
+++ b/sbt-twirl/src/main/scala/play/twirl/sbt/SbtTwirl.scala
@@ -86,10 +86,10 @@ object SbtTwirl extends AutoPlugin {
       libraryDependencies += {
         val crossVer = crossVersion.value
         val isScalaJS = CrossVersion(crossVer, scalaVersion.value, scalaBinaryVersion.value) match {
-          case Some(f) => f("").contains("_sjs0.6") // detect ScalaJS CrossVersion
+          case Some(f) => f("").contains("_sjs1") // detect ScalaJS CrossVersion
           case None    => false
         }
-        // TODO: use %%% from sbt-crossproject when we add support for scalajs 1.0
+        // TODO: can we use %%% from sbt-crossproject now that we're on Scala.js 1.x?
         val baseModuleID = "com.typesafe.play" %% "twirl-api" % twirlVersion.value
         if (isScalaJS) baseModuleID.cross(crossVer) else baseModuleID
       }

--- a/sbt-twirl/src/sbt-test/twirl/scalajs-compile/project/plugins.sbt
+++ b/sbt-twirl/src/sbt-test/twirl/scalajs-compile/project/plugins.sbt
@@ -1,2 +1,2 @@
 addSbtPlugin("com.typesafe.sbt" % "sbt-twirl" % sys.props("project.version"))
-addSbtPlugin("org.scala-js" % "sbt-scalajs" % "1.4.0")
+addSbtPlugin("org.scala-js" % "sbt-scalajs" % "1.5.0")

--- a/sbt-twirl/src/sbt-test/twirl/scalajs-compile/project/plugins.sbt
+++ b/sbt-twirl/src/sbt-test/twirl/scalajs-compile/project/plugins.sbt
@@ -1,3 +1,2 @@
 addSbtPlugin("com.typesafe.sbt" % "sbt-twirl" % sys.props("project.version"))
-
-addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.33")
+addSbtPlugin("org.scala-js" % "sbt-scalajs" % "1.4.0")


### PR DESCRIPTION
Motivation: I want everything modernized before I take a stab at adding Scala 3 support.

About the Scala.js upgrade, it's true that upgrading to 1.4.0 means users must use 1.4.0 as well, but I checked in with Seb about that recently and he says don't think about it just do it, as he has said a number of times before. It's considered normal in the Scala.js world that in order to upgrade your libraries you may need to be on latest Scala.js first.