### PR TITLE
[1.5.x] Also publish twirl-api_sjs0.6 local for scripted test

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -185,7 +185,7 @@ lazy val plugin = project
       publishLocal
         .all(
           ScopeFilter(
-            inDependencies(compiler)
+            inAnyProject
           )
         )
         .value


### PR DESCRIPTION
Fixes #406

When running scripted tests we need to make sure that also twirl-api_sjs gets published locally.

I was not sure if `inAnyProject` is too much (like too many projects get published which maybe shouldn't), so I did two runs and see what gets published: First run was without my pull request, second run was with the patch applied:

<details>
 <summary>Output without the patch</summary>

```
sbt:twirl> release
[info] Checking remote [upstream] ...
[warn] There may be incompatibilities among your library dependencies; run 'evicted' to see detailed eviction warnings.
[warn] There may be incompatibilities among your library dependencies; run 'evicted' to see detailed eviction warnings.
[success] Total time: 0 s, completed Mar 19, 2021 08:53:07 AM
[info] Wrote /home/mkurz/work/twirl/api/jvm/target/scala-2.12/twirl-api_2.12-1.5.1.pom
[info] Wrote /home/mkurz/work/twirl/parser/target/scala-2.12/twirl-parser_2.12-1.5.1.pom
[warn] There may be incompatibilities among your library dependencies; run 'evicted' to see detailed eviction warnings.
[info] Main Scala API documentation to /home/mkurz/work/twirl/api/jvm/target/scala-2.12/api...
model contains 58 documentable templates
[info] Main Scala API documentation successful.
[info] Main Scala API documentation to /home/mkurz/work/twirl/parser/target/scala-2.12/api...
model contains 24 documentable templates
[info] Main Scala API documentation successful.
[info] Wrote /home/mkurz/work/twirl/compiler/target/scala-2.12/twirl-compiler_2.12-1.5.1.pom
[info] Compiling 10 Scala sources to /home/mkurz/work/twirl/api/jvm/target/scala-2.12/classes ...
[info] Compiling 3 Scala sources to /home/mkurz/work/twirl/parser/target/scala-2.12/classes ...
[warn] There may be incompatibilities among your library dependencies; run 'evicted' to see detailed eviction warnings.
[info] Main Scala API documentation to /home/mkurz/work/twirl/compiler/target/scala-2.12/api...
model contains 24 documentable templates
[info] Main Scala API documentation successful.
[info] :: delivering :: com.typesafe.play#twirl-parser_2.12;1.5.1 :: 1.5.1 :: release :: Fri Mar 19 08:53:07 CET 2021
[info]  delivering ivy file to /home/mkurz/work/twirl/parser/target/scala-2.12/ivy-1.5.1.xml
[info]  published twirl-parser_2.12 to /home/mkurz/.ivy2/local/com.typesafe.play/twirl-parser_2.12/1.5.1/poms/twirl-parser_2.12.pom
[info]  published twirl-parser_2.12 to /home/mkurz/.ivy2/local/com.typesafe.play/twirl-parser_2.12/1.5.1/jars/twirl-parser_2.12.jar
[info]  published twirl-parser_2.12 to /home/mkurz/.ivy2/local/com.typesafe.play/twirl-parser_2.12/1.5.1/srcs/twirl-parser_2.12-sources.jar
[info]  published twirl-parser_2.12 to /home/mkurz/.ivy2/local/com.typesafe.play/twirl-parser_2.12/1.5.1/docs/twirl-parser_2.12-javadoc.jar
[info]  published ivy to /home/mkurz/.ivy2/local/com.typesafe.play/twirl-parser_2.12/1.5.1/ivys/ivy.xml
[info] :: delivering :: com.typesafe.play#twirl-api_2.12;1.5.1 :: 1.5.1 :: release :: Fri Mar 19 08:53:07 CET 2021
[info]  delivering ivy file to /home/mkurz/work/twirl/api/jvm/target/scala-2.12/ivy-1.5.1.xml
[info]  published twirl-api_2.12 to /home/mkurz/.ivy2/local/com.typesafe.play/twirl-api_2.12/1.5.1/jars/twirl-api_2.12.jar
[info]  published twirl-api_2.12 to /home/mkurz/.ivy2/local/com.typesafe.play/twirl-api_2.12/1.5.1/docs/twirl-api_2.12-javadoc.jar
[info]  published twirl-api_2.12 to /home/mkurz/.ivy2/local/com.typesafe.play/twirl-api_2.12/1.5.1/poms/twirl-api_2.12.pom
[info]  published twirl-api_2.12 to /home/mkurz/.ivy2/local/com.typesafe.play/twirl-api_2.12/1.5.1/srcs/twirl-api_2.12-sources.jar
[info]  published twirl-api_2.12 to /home/mkurz/.ivy2/local/com.typesafe.play/twirl-api_2.12/1.5.1/jars/twirl-api_2.12-playdoc.jar
[info]  published ivy to /home/mkurz/.ivy2/local/com.typesafe.play/twirl-api_2.12/1.5.1/ivys/ivy.xml
[info] Compiling 1 Scala source and 1 Java source to /home/mkurz/work/twirl/compiler/target/scala-2.12/classes ...
[info] Main Scala API documentation to /home/mkurz/work/twirl/sbt-twirl/target/scala-2.12/sbt-1.0/api...
model contains 20 documentable templates
[info] Main Scala API documentation successful.
[info] :: delivering :: com.typesafe.play#twirl-compiler_2.12;1.5.1 :: 1.5.1 :: release :: Fri Mar 19 08:53:07 CET 2021
[info]  delivering ivy file to /home/mkurz/work/twirl/compiler/target/scala-2.12/ivy-1.5.1.xml
[info]  published twirl-compiler_2.12 to /home/mkurz/.ivy2/local/com.typesafe.play/twirl-compiler_2.12/1.5.1/poms/twirl-compiler_2.12.pom
[info]  published twirl-compiler_2.12 to /home/mkurz/.ivy2/local/com.typesafe.play/twirl-compiler_2.12/1.5.1/jars/twirl-compiler_2.12.jar
[info]  published twirl-compiler_2.12 to /home/mkurz/.ivy2/local/com.typesafe.play/twirl-compiler_2.12/1.5.1/srcs/twirl-compiler_2.12-sources.jar
[info]  published twirl-compiler_2.12 to /home/mkurz/.ivy2/local/com.typesafe.play/twirl-compiler_2.12/1.5.1/docs/twirl-compiler_2.12-javadoc.jar
[info]  published ivy to /home/mkurz/.ivy2/local/com.typesafe.play/twirl-compiler_2.12/1.5.1/ivys/ivy.xml
[info] Compiling 5 Scala sources to /home/mkurz/work/twirl/sbt-twirl/target/scala-2.12/sbt-1.0/classes ...
[info] :: delivering :: com.typesafe.sbt#sbt-twirl;1.5.1 :: 1.5.1 :: release :: Fri Mar 19 08:53:07 CET 2021
[info]  delivering ivy file to /home/mkurz/work/twirl/sbt-twirl/target/scala-2.12/sbt-1.0/ivy-1.5.1.xml
[info]  published sbt-twirl to /home/mkurz/.ivy2/local/com.typesafe.sbt/sbt-twirl/scala_2.12/sbt_1.0/1.5.1/jars/sbt-twirl.jar
[info]  published sbt-twirl to /home/mkurz/.ivy2/local/com.typesafe.sbt/sbt-twirl/scala_2.12/sbt_1.0/1.5.1/srcs/sbt-twirl-sources.jar
[info]  published sbt-twirl to /home/mkurz/.ivy2/local/com.typesafe.sbt/sbt-twirl/scala_2.12/sbt_1.0/1.5.1/docs/sbt-twirl-javadoc.jar
[info]  published ivy to /home/mkurz/.ivy2/local/com.typesafe.sbt/sbt-twirl/scala_2.12/sbt_1.0/1.5.1/ivys/ivy.xml
[info] Compiling 2 Scala sources to /home/mkurz/work/twirl/sbt-twirl/target/scala-2.12/sbt-1.0/test-classes ...
Running twirl / scalajs-compile
... etc.
```

</details>

<details>
 <summary>Output with the patch applied</summary>

```
sbt:twirl> release
sbt:twirl> release
[info] Checking remote [upstream] ...
[warn] There may be incompatibilities among your library dependencies; run 'evicted' to see detailed eviction warnings.
[warn] There may be incompatibilities among your library dependencies; run 'evicted' to see detailed eviction warnings.
[success] Total time: 0 s, completed Mar 19, 2021 08:53:07 AM
[info] Wrote /home/mkurz/work/twirl/api/jvm/target/scala-2.12/twirl-api_2.12-1.5.1.pom
[info] Wrote /home/mkurz/work/twirl/parser/target/scala-2.12/twirl-parser_2.12-1.5.1.pom
[info] Wrote /home/mkurz/work/twirl/api/js/target/scala-2.12/twirl-api_sjs0.6_2.12-1.5.1.pom
[warn] There may be incompatibilities among your library dependencies; run 'evicted' to see detailed eviction warnings.
[info] Main Scala API documentation to /home/mkurz/work/twirl/api/jvm/target/scala-2.12/api...
model contains 58 documentable templates
[info] Main Scala API documentation successful.
[info] Main Scala API documentation to /home/mkurz/work/twirl/parser/target/scala-2.12/api...
model contains 24 documentable templates
[info] Main Scala API documentation successful.
[info] Wrote /home/mkurz/work/twirl/compiler/target/scala-2.12/twirl-compiler_2.12-1.5.1.pom
[info] Compiling 10 Scala sources to /home/mkurz/work/twirl/api/jvm/target/scala-2.12/classes ...
[info] Compiling 3 Scala sources to /home/mkurz/work/twirl/parser/target/scala-2.12/classes ...
[warn] There may be incompatibilities among your library dependencies; run 'evicted' to see detailed eviction warnings.
[info] Main Scala API documentation to /home/mkurz/work/twirl/api/js/target/scala-2.12/api...
model contains 58 documentable templates
[info] Main Scala API documentation successful.
[info] Main Scala API documentation to /home/mkurz/work/twirl/compiler/target/scala-2.12/api...
model contains 24 documentable templates
[info] Main Scala API documentation successful.
[info] :: delivering :: com.typesafe.play#twirl-parser_2.12;1.5.1 :: 1.5.1 :: release :: Fri Mar 19 08:53:07 CET 2021
[info]  delivering ivy file to /home/mkurz/work/twirl/parser/target/scala-2.12/ivy-1.5.1.xml
[info]  published twirl-parser_2.12 to /home/mkurz/.ivy2/local/com.typesafe.play/twirl-parser_2.12/1.5.1/poms/twirl-parser_2.12.pom
[info]  published twirl-parser_2.12 to /home/mkurz/.ivy2/local/com.typesafe.play/twirl-parser_2.12/1.5.1/jars/twirl-parser_2.12.jar
[info]  published twirl-parser_2.12 to /home/mkurz/.ivy2/local/com.typesafe.play/twirl-parser_2.12/1.5.1/srcs/twirl-parser_2.12-sources.jar
[info]  published twirl-parser_2.12 to /home/mkurz/.ivy2/local/com.typesafe.play/twirl-parser_2.12/1.5.1/docs/twirl-parser_2.12-javadoc.jar
[info]  published ivy to /home/mkurz/.ivy2/local/com.typesafe.play/twirl-parser_2.12/1.5.1/ivys/ivy.xml
[info] Compiling 10 Scala sources to /home/mkurz/work/twirl/api/js/target/scala-2.12/classes ...
[info] :: delivering :: com.typesafe.play#twirl-api_2.12;1.5.1 :: 1.5.1 :: release :: Fri Mar 19 08:53:07 CET 2021
[info]  delivering ivy file to /home/mkurz/work/twirl/api/jvm/target/scala-2.12/ivy-1.5.1.xml
[info]  published twirl-api_2.12 to /home/mkurz/.ivy2/local/com.typesafe.play/twirl-api_2.12/1.5.1/jars/twirl-api_2.12.jar
[info]  published twirl-api_2.12 to /home/mkurz/.ivy2/local/com.typesafe.play/twirl-api_2.12/1.5.1/docs/twirl-api_2.12-javadoc.jar
[info]  published twirl-api_2.12 to /home/mkurz/.ivy2/local/com.typesafe.play/twirl-api_2.12/1.5.1/poms/twirl-api_2.12.pom
[info]  published twirl-api_2.12 to /home/mkurz/.ivy2/local/com.typesafe.play/twirl-api_2.12/1.5.1/srcs/twirl-api_2.12-sources.jar
[info]  published twirl-api_2.12 to /home/mkurz/.ivy2/local/com.typesafe.play/twirl-api_2.12/1.5.1/jars/twirl-api_2.12-playdoc.jar
[info]  published ivy to /home/mkurz/.ivy2/local/com.typesafe.play/twirl-api_2.12/1.5.1/ivys/ivy.xml
[info] Compiling 1 Scala source and 1 Java source to /home/mkurz/work/twirl/compiler/target/scala-2.12/classes ...
[info] :: delivering :: com.typesafe.play#twirl-api_sjs0.6_2.12;1.5.1 :: 1.5.1 :: release :: Fri Mar 19 01:00:30 CET 2021
[info]  delivering ivy file to /home/mkurz/work/twirl/api/js/target/scala-2.12/ivy-1.5.1.xml
[info]  published twirl-api_sjs0.6_2.12 to /home/mkurz/.ivy2/local/com.typesafe.play/twirl-api_sjs0.6_2.12/1.5.1/jars/twirl-api_sjs0.6_2.12.jar
[info]  published twirl-api_sjs0.6_2.12 to /home/mkurz/.ivy2/local/com.typesafe.play/twirl-api_sjs0.6_2.12/1.5.1/docs/twirl-api_sjs0.6_2.12-javadoc.jar
[info]  published twirl-api_sjs0.6_2.12 to /home/mkurz/.ivy2/local/com.typesafe.play/twirl-api_sjs0.6_2.12/1.5.1/poms/twirl-api_sjs0.6_2.12.pom
[info]  published twirl-api_sjs0.6_2.12 to /home/mkurz/.ivy2/local/com.typesafe.play/twirl-api_sjs0.6_2.12/1.5.1/srcs/twirl-api_sjs0.6_2.12-sources.jar
[info]  published twirl-api_sjs0.6_2.12 to /home/mkurz/.ivy2/local/com.typesafe.play/twirl-api_sjs0.6_2.12/1.5.1/jars/twirl-api_sjs0.6_2.12-playdoc.jar
[info]  published ivy to /home/mkurz/.ivy2/local/com.typesafe.play/twirl-api_sjs0.6_2.12/1.5.1/ivys/ivy.xml
[info] Main Scala API documentation to /home/mkurz/work/twirl/sbt-twirl/target/scala-2.12/sbt-1.0/api...
model contains 20 documentable templates
[info] Main Scala API documentation successful.
[info] :: delivering :: com.typesafe.play#twirl-compiler_2.12;1.5.1 :: 1.5.1 :: release :: Fri Mar 19 08:53:07 CET 2021
[info]  delivering ivy file to /home/mkurz/work/twirl/compiler/target/scala-2.12/ivy-1.5.1.xml
[info]  published twirl-compiler_2.12 to /home/mkurz/.ivy2/local/com.typesafe.play/twirl-compiler_2.12/1.5.1/poms/twirl-compiler_2.12.pom
[info]  published twirl-compiler_2.12 to /home/mkurz/.ivy2/local/com.typesafe.play/twirl-compiler_2.12/1.5.1/jars/twirl-compiler_2.12.jar
[info]  published twirl-compiler_2.12 to /home/mkurz/.ivy2/local/com.typesafe.play/twirl-compiler_2.12/1.5.1/srcs/twirl-compiler_2.12-sources.jar
[info]  published twirl-compiler_2.12 to /home/mkurz/.ivy2/local/com.typesafe.play/twirl-compiler_2.12/1.5.1/docs/twirl-compiler_2.12-javadoc.jar
[info]  published ivy to /home/mkurz/.ivy2/local/com.typesafe.play/twirl-compiler_2.12/1.5.1/ivys/ivy.xml
[info] Compiling 5 Scala sources to /home/mkurz/work/twirl/sbt-twirl/target/scala-2.12/sbt-1.0/classes ...
[info] :: delivering :: com.typesafe.sbt#sbt-twirl;1.5.1 :: 1.5.1 :: release :: Fri Mar 19 08:53:07 CET 2021
[info]  delivering ivy file to /home/mkurz/work/twirl/sbt-twirl/target/scala-2.12/sbt-1.0/ivy-1.5.1.xml
[info]  published sbt-twirl to /home/mkurz/.ivy2/local/com.typesafe.sbt/sbt-twirl/scala_2.12/sbt_1.0/1.5.1/jars/sbt-twirl.jar
[info]  published sbt-twirl to /home/mkurz/.ivy2/local/com.typesafe.sbt/sbt-twirl/scala_2.12/sbt_1.0/1.5.1/srcs/sbt-twirl-sources.jar
[info]  published sbt-twirl to /home/mkurz/.ivy2/local/com.typesafe.sbt/sbt-twirl/scala_2.12/sbt_1.0/1.5.1/docs/sbt-twirl-javadoc.jar
[info]  published ivy to /home/mkurz/.ivy2/local/com.typesafe.sbt/sbt-twirl/scala_2.12/sbt_1.0/1.5.1/ivys/ivy.xml
[info] Compiling 2 Scala sources to /home/mkurz/work/twirl/sbt-twirl/target/scala-2.12/sbt-1.0/test-classes ...
Running twirl / scalajs-compile
... etc.
```

</details>

If you now [diff these two outputs](https://www.diffchecker.com/yvMxbRsl) you will see that with the patch only twirl-api_sjs0.6 gets published in addition, exactly what we want.

So now with this PR the scripted test find all their dependencies