### PR TITLE
Downgrade scala-parser-combinators and scala-xml

### DIFF
--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -1,2 +1,8 @@
 pullRequests.frequency = "@weekly"
 commits.message = "${artifactName} ${nextVersion} (was ${currentVersion})"
+
+updates.pin = [
+  // See comment in build.sbt why we want to pin these two deps to 1.x
+  { groupId = "org.scala-lang.modules", artifactId = "scala-xml", version = "1." },
+  { groupId = "org.scala-lang.modules", artifactId = "scala-parser-combinators", version = "1." }
+]

--- a/build.sbt
+++ b/build.sbt
@@ -5,12 +5,14 @@ import org.scalajs.jsenv.nodejs.NodeJSEnv
 // Binary compatibility is this version
 val previousVersion: Option[String] = Some("1.5.0")
 
-val ScalaTestVersion              = "3.2.9"
-val ScalaParserCombinatorsVersion = "2.0.0"
+val ScalaTestVersion = "3.2.9"
 
-val ScalaXmlVersion = "2.0.1"
-// Next line can be removed when dropping Scala 2.12? See https://github.com/playframework/twirl/pull/424
-ThisBuild / libraryDependencySchemes += "org.scala-lang.modules" %% "scala-xml" % VersionScheme.Always
+// Do NOT upgrade these dependencies to 2.x or newer! twirl is a sbt-plugin
+// and gets published with Scala 2.12, therefore we need to stay at the same major version
+// like the 2.12.x Scala compiler, otherwise we run into conflicts when using sbt 1.5+
+// See https://github.com/scala/scala/pull/9743
+val ScalaParserCombinatorsVersion = "1.1.2" // Do not upgrade beyond 1.x
+val ScalaXmlVersion               = "1.3.0" // Do not upgrade beyond 1.x
 
 val mimaSettings = Seq(
   mimaPreviousArtifacts := previousVersion.map(organization.value %% name.value % _).toSet

--- a/docs/project/plugins.sbt
+++ b/docs/project/plugins.sbt
@@ -7,6 +7,3 @@ resolvers ++= DefaultOptions.resolvers(snapshot = true)
 addSbtPlugin("com.typesafe.play" % "play-docs-sbt-plugin" % sys.props.getOrElse("play.version", "2.8.0"))
 addSbtPlugin("de.heikoseeberger" % "sbt-header"           % "5.6.0")
 addSbtPlugin("org.scalameta"     % "sbt-scalafmt"         % "2.4.3")
-
-// Next line can be removed when dropping Scala 2.12? See https://github.com/playframework/twirl/pull/424
-ThisBuild / libraryDependencySchemes += "org.scala-lang.modules" %% "scala-xml" % VersionScheme.Always

--- a/sbt-twirl/src/sbt-test/twirl/compile/project/plugins.sbt
+++ b/sbt-twirl/src/sbt-test/twirl/compile/project/plugins.sbt
@@ -1,4 +1,1 @@
 addSbtPlugin("com.typesafe.sbt" % "sbt-twirl" % sys.props("project.version"))
-
-// Next line can be removed when dropping Scala 2.12? See https://github.com/playframework/twirl/pull/424
-ThisBuild / libraryDependencySchemes += "org.scala-lang.modules" %% "scala-xml" % VersionScheme.Always

--- a/sbt-twirl/src/sbt-test/twirl/scalajs-compile/project/plugins.sbt
+++ b/sbt-twirl/src/sbt-test/twirl/scalajs-compile/project/plugins.sbt
@@ -1,6 +1,2 @@
 addSbtPlugin("com.typesafe.sbt" % "sbt-twirl" % sys.props("project.version"))
 addSbtPlugin("org.scala-js" % "sbt-scalajs" % "1.7.0")
-
-// Next line can be removed when dropping Scala 2.12? See https://github.com/playframework/twirl/pull/424
-ThisBuild / libraryDependencySchemes += "org.scala-lang.modules" %% "scala-xml" % VersionScheme.Always
-


### PR DESCRIPTION
twirl is a sbt-plugin. sbt-plugins get published for Scala 2.12.
The 2.12.x scala compiler depends on 1.x versions for both scala-parser-combinators and scala-xml, see https://github.com/scala/scala/blob/2.12.x/versions.properties#L21-L22
If we would use 2.x versions, we would run into annoying dependency conflicts in sbt 1.5+
There is no need to upgrade these versions to 2.x, the only reason would be if we would cross build for Scala 3, but sbt-plugins do not need to be cross build for Scala 3.

See discussion in https://github.com/scala/scala/pull/9743