### PR TITLE
[BACKPORT] Bump SBT and scala versions for 1.4.x series 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,8 @@ language: scala
 scala:
   - 2.10.7
   - 2.11.12
-  - 2.12.8
-  - 2.13.0
+  - 2.12.15
+  - 2.13.6
 
 env:
   - TRAVIS_JDK=8

--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,10 @@
-import interplay.ScalaVersions._
 import sbtcrossproject.crossProject
 import org.scalajs.jsenv.nodejs.NodeJSEnv
+
+val scala210 = "2.10.7"
+val scala211 = "2.11.12"
+val scala212 = "2.12.15"
+val scala213 = "2.13.6"
 
 def binaryCompatibilitySettings(org: String, moduleName: String, scalaBinVersion: String): Set[ModuleID] = {
   val artifact = org % s"${moduleName}_${scalaBinVersion}"

--- a/docs/build.sbt
+++ b/docs/build.sbt
@@ -3,7 +3,7 @@ lazy val docs = project
   .enablePlugins(PlayDocsPlugin)
   .configs(Configuration.of("Docs", "docs"))
   .settings(
-    scalaVersion := "2.12.8",
+    scalaVersion := "2.12.15",
     // use special snapshot play version for now
     resolvers ++= DefaultOptions.resolvers(snapshot = true),
     resolvers += Resolver.typesafeRepo("releases"),

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.5.7
+sbt.version=1.5.8

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.2.8
+sbt.version=1.5.7

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,7 +1,7 @@
-addSbtPlugin("com.typesafe.play" % "interplay" % sys.props.get("interplay.version").getOrElse("2.0.8"))
+addSbtPlugin("com.typesafe.play" % "interplay" % sys.props.get("interplay.version").getOrElse("2.1.9"))
 
 // For the Cross Build
-addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.28")
+addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.33")
 
 addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject" % "0.6.0")
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,4 +1,4 @@
-addSbtPlugin("com.typesafe.play" % "interplay" % sys.props.get("interplay.version").getOrElse("2.1.9"))
+addSbtPlugin("com.typesafe.play" % "interplay" % sys.props.get("interplay.version").getOrElse("2.0.8"))
 
 // For the Cross Build
 addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.33")

--- a/sbt-twirl/src/sbt-test/twirl/scalajs-compile/project/plugins.sbt
+++ b/sbt-twirl/src/sbt-test/twirl/scalajs-compile/project/plugins.sbt
@@ -1,3 +1,3 @@
 addSbtPlugin("com.typesafe.sbt" % "sbt-twirl" % sys.props("project.version"))
 
-addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.28")
+addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.33")


### PR DESCRIPTION
Twirl 1.4.x is the last series with Scala 2.11 support. I'm bumping SBT and Scala versions here to enable Scala 2.11 projects that use Twirl to upgrade to SBT >=1.5.0. For more details see: https://github.com/sbt/sbt/issues/6400

This is a backport/fix, similar to what @mkurz did in https://github.com/playframework/twirl/pull/402 for the 1.5.x series. @mkurz if there's any other change I need to make here just let me know, thanks!