### PR TITLE
Update scalafmt to 3.3.1

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,4 +1,6 @@
-version = 3.0.8
+version = 3.3.1
+
+runner.dialect = scala213
 
 align.preset = true
 danglingParentheses.preset = true


### PR DESCRIPTION
In recent versions of scalafmt, setting ruuner.dialect is mandatory.

The current configuration file does not have runner.dialect set.
Hence we are in a state where we cannot accept pull requests by scala-steward.
https://github.com/playframework/twirl/pull/474