### PR TITLE
Add syntax related fixes for Scala3 cross build

### DIFF
--- a/api/shared/src/main/scala/play/twirl/api/TemplateMagic.scala
+++ b/api/shared/src/main/scala/play/twirl/api/TemplateMagic.scala
@@ -17,13 +17,13 @@ object TemplateMagic {
 
   // --- IF
 
-  implicit def iterableToBoolean(x: Iterable[_]) = x != null && !x.isEmpty
-  implicit def optionToBoolean(x: Option[_])     = x != null && x.isDefined
-  implicit def stringToBoolean(x: String)        = x != null && !x.isEmpty
+  implicit def iterableToBoolean(x: Iterable[_]): Boolean = x != null && !x.isEmpty
+  implicit def optionToBoolean(x: Option[_]): Boolean     = x != null && x.isDefined
+  implicit def stringToBoolean(x: String): Boolean        = x != null && !x.isEmpty
 
   // --- JAVA
 
-  implicit def javaCollectionToScala[T](x: java.lang.Iterable[T]) = {
+  implicit def javaCollectionToScala[T](x: java.lang.Iterable[T]): Iterable[T] = {
     import scala.collection.JavaConverters._
     x.asScala
   }
@@ -42,7 +42,7 @@ object TemplateMagic {
       }
   }
 
-  implicit def anyToDefault(x: Any) = Default(x)
+  implicit def anyToDefault(x: Any): Default = Default(x)
 
   // --- DATE
 
@@ -52,7 +52,7 @@ object TemplateMagic {
     }
   }
 
-  implicit def richDate(date: java.util.Date) = new RichDate(date)
+  implicit def richDate(date: java.util.Date): RichDate = new RichDate(date)
 
   // --- STRING
 
@@ -65,5 +65,5 @@ object TemplateMagic {
     }
   }
 
-  implicit def richString(string: String) = new RichString(string)
+  implicit def richString(string: String): RichString = new RichString(string)
 }

--- a/compiler/src/main/scala/play/twirl/compiler/TwirlCompiler.scala
+++ b/compiler/src/main/scala/play/twirl/compiler/TwirlCompiler.scala
@@ -247,7 +247,7 @@ object TwirlCompiler {
   ) = {
     val templateParser = new TwirlParser(inclusiveDot)
     templateParser.parse(new String(content, codec.charSet)) match {
-      case templateParser.Success(parsed: Template, rest) if rest.atEnd => {
+      case templateParser.Success(parsed: Template, rest) if rest.atEnd() => {
         generateFinalTemplate(
           relativePath,
           content,
@@ -261,7 +261,7 @@ object TwirlCompiler {
         )
       }
       case templateParser.Success(_, rest) => {
-        throw new TemplateCompilationError(new File(relativePath), "Not parsed?", rest.pos.line, rest.pos.column)
+        throw new TemplateCompilationError(new File(relativePath), "Not parsed?", rest.pos().line, rest.pos().column)
       }
       case templateParser.Error(_, rest, errors) => {
         val firstError = errors.head

--- a/parser/src/test/scala/play/twirl/parser/test/ParserSpec.scala
+++ b/parser/src/test/scala/play/twirl/parser/test/ParserSpec.scala
@@ -49,7 +49,7 @@ class ParserSpec extends AnyWordSpec with Matchers with Inside {
   def parseTemplateString(template: String): Template = {
     parser.parse(template) match {
       case parser.Success(tmpl, input) =>
-        if (!input.atEnd) sys.error("Template parsed but not at source end")
+        if (!input.atEnd()) sys.error("Template parsed but not at source end")
         tmpl
       case parser.Error(_, _, errors) =>
         sys.error("Template failed to parse: " + errors.head.str)


### PR DESCRIPTION
I know there are already some people working on cross-building in Scala3. But I'm going to try it too.

The following fixes have been added with this PR.
- Specify the return type for "implicit def
- Stop calling methods without "()".

We probably have a lot more work to do for the Scala3 cross-build,
I think it's better to get these fixes in first.
It will reduce noise and make it easier to work and review code.