### PR TITLE
avoid deprecated `java.lang.Class.newInstance`

### DIFF
--- a/parser/src/main/scala/play/twirl/parser/TwirlParser.scala
+++ b/parser/src/main/scala/play/twirl/parser/TwirlParser.scala
@@ -331,7 +331,8 @@ class TwirlParser(val shouldParseInclusiveDot: Boolean) {
   def several[T, BufferType <: mutable.Buffer[T]](parser: () => T, provided: BufferType = null)(implicit
       manifest: Manifest[BufferType]
   ): BufferType = {
-    val ab     = if (provided != null) provided else manifest.runtimeClass.newInstance().asInstanceOf[BufferType]
+    val ab =
+      if (provided != null) provided else manifest.runtimeClass.getConstructor().newInstance().asInstanceOf[BufferType]
     var parsed = parser()
     while (parsed != null) {
       ab += parsed


### PR DESCRIPTION
https://app.travis-ci.com/github/playframework/twirl/jobs/554186867#L356

```
[warn] /home/travis/build/playframework/twirl/parser/src/main/scala/play/twirl/parser/TwirlParser.scala:334:76: method newInstance in class Class is deprecated
[warn]     val ab     = if (provided != null) provided else manifest.runtimeClass.newInstance().asInstanceOf[BufferType]
[warn]                                                                            ^
[info] done compiling
```