### PR TITLE
Add a testcase for By-name parameters

### DIFF
--- a/compiler/src/test/resources/callByName.scala.html
+++ b/compiler/src/test/resources/callByName.scala.html
@@ -1,0 +1,3 @@
+@(name: => String)
+
+<h1>Hello @name!</h1>

--- a/compiler/src/test/scala/play/twirl/compiler/test/CompilerSpec.scala
+++ b/compiler/src/test/scala/play/twirl/compiler/test/CompilerSpec.scala
@@ -164,7 +164,7 @@ class CompilerSpec extends AnyWordSpec with Matchers {
     "compile successfully (call by name)" in {
       val helper = newCompilerHelper
       val text = helper
-        .compile[(String => Html)]("callByName.scala.html", "html.callByName")
+        .compile[((=> String) => Html)]("callByName.scala.html", "html.callByName")
         .static("World")
         .toString
         .trim

--- a/compiler/src/test/scala/play/twirl/compiler/test/CompilerSpec.scala
+++ b/compiler/src/test/scala/play/twirl/compiler/test/CompilerSpec.scala
@@ -161,6 +161,16 @@ class CompilerSpec extends AnyWordSpec with Matchers {
       text must be("123456")
     }
 
+    "compile successfully (call by name)" in {
+      val helper = newCompilerHelper
+      val text = helper
+        .compile[(String => Html)]("callByName.scala.html", "html.callByName")
+        .static("World")
+        .toString
+        .trim
+      text must be("<h1>Hello World!</h1>")
+    }
+
     "fail compilation for error.scala.html" in {
       val helper = newCompilerHelper
       the[CompilationError] thrownBy helper.compile[(() => Html)]("error.scala.html", "html.error") must have(


### PR DESCRIPTION
Twirl is implemented taking into account the By-Name parameter of the template argument.
https://github.com/playframework/twirl/blob/a6c8e45a797ef85847fbd94274023ff023682152/compiler/src/main/scala/play/twirl/compiler/TwirlCompiler.scala#L549

However, there is no test case for it.
I would like to add a test case to make it safer to support cross-building with Scala3.