### PR TITLE
Call toIndexedSeq explicitly to reduce warnings

### DIFF
--- a/compiler/src/main/scala/play/twirl/compiler/TwirlCompiler.scala
+++ b/compiler/src/main/scala/play/twirl/compiler/TwirlCompiler.scala
@@ -68,7 +68,7 @@ sealed trait AbstractGeneratedSource {
 
   lazy val matrix: Seq[(Int, Int)] = {
     for {
-      pos <- meta("MATRIX").split('|')
+      pos <- meta("MATRIX").split('|').toIndexedSeq
       c = pos.split("->")
     } yield try {
       Integer.parseInt(c(0)) -> Integer.parseInt(c(1))
@@ -79,7 +79,7 @@ sealed trait AbstractGeneratedSource {
 
   lazy val lines: Seq[(Int, Int)] = {
     for {
-      pos <- meta("LINES").split('|')
+      pos <- meta("LINES").split('|').toIndexedSeq
       c = pos.split("->")
     } yield try {
       Integer.parseInt(c(0)) -> Integer.parseInt(c(1))


### PR DESCRIPTION
To reduce the following warnings.

```console
[warn] /workspace/twirl/compiler/src/main/scala/play/twirl/compiler/TwirlCompiler.scala:71:11: method copyArrayToImmutableIndexedSeq in class LowPriorityImplicits2 is deprecated (since 2.13.0): Implicit conversions from Array to immutable.IndexedSeq are implemented by copying; Use the more efficient non-copying ArraySeq.unsafeWrapArray or an explicit toIndexedSeq call
[warn]       pos <- meta("MATRIX").split('|')
[warn]           ^
[warn] /workspace/twirl/compiler/src/main/scala/play/twirl/compiler/TwirlCompiler.scala:82:11: method copyArrayToImmutableIndexedSeq in class LowPriorityImplicits2 is deprecated (since 2.13.0): Implicit conversions from Array to immutable.IndexedSeq are implemented by copying; Use the more efficient non-copying ArraySeq.unsafeWrapArray or an explicit toIndexedSeq call
[warn]       pos <- meta("LINES").split('|')
[warn]           ^
```