### PR TITLE
Fix release by tag

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,8 +10,4 @@ jobs:
   publish-artifacts:
     name: Publish / Artifacts
     uses: playframework/.github/.github/workflows/publish.yml@v2
-    secrets:
-      username: ${{ secrets.SONATYPE_USERNAME }}
-      password: ${{ secrets.SONATYPE_PASSWORD }}
-      pgp_passphrase: ${{ secrets.PGP_PASSPHRASE }}
-      pgp_secret: ${{ secrets.PGP_SECRET }}
+    secrets: inherit

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: # Snapshots
       - main
-    tags: ['*'] # Releases
+    tags: ['**'] # Releases
 
 jobs:
   publish-artifacts:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: # Snapshots
       - main
-    tags: ["*"] # Releases
+    tags: ['*'] # Releases
 
 jobs:
   publish-artifacts:


### PR DESCRIPTION
@octonato just tagged `1.6.0-M2`, however not artifacts got pushed to maven central.

I think this is because of using double quotes...