### PR TITLE
Allow defining result type for local methods (needed for Scala 3 implicits)

### DIFF
--- a/compiler/src/main/scala/play/twirl/compiler/TwirlCompiler.scala
+++ b/compiler/src/main/scala/play/twirl/compiler/TwirlCompiler.scala
@@ -406,14 +406,14 @@ object TwirlCompiler {
           t.params.pos
         ) :+ ":" :+ resultType :+ " = {_display_(" :+ templateCode(t, resultType) :+ ")};"
       }
-      case Def(name, params, block) => {
+      case Def(name, params, resultType, block) => {
         Nil :+ (if (name.str.startsWith("implicit")) "implicit def " else "def ") :+ Source(
           name.str,
           name.pos
         ) :+ Source(
           params.str,
           params.pos
-        ) :+ " = {" :+ block.code :+ "};"
+        ) :+ resultType.map(":" + _.str).getOrElse("") :+ " = {" :+ block.code :+ "};"
       }
     }
 

--- a/compiler/src/test/resources/localDef.scala.html
+++ b/compiler/src/test/resources/localDef.scala.html
@@ -1,0 +1,19 @@
+@****************************************************************************************************************************************************
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com> *
+ ****************************************************************************************************************************************************@
+
+@()
+
+@person(firstname: String, lastname: String) = @{
+    s"$firstname-$lastname"
+}
+@country(city: String, country: String): String = @{
+    s"$city-$country"
+}
+@region(continent: String):String=@{
+    s"$continent"
+}
+@slogan()=@{ s"The High Velocity Web Framework For Java and Scala" }
+@year=@{ s"2023" }
+
+@person("Play", "Framework")-@country("Vienna", "Austria")-@region("Europe")-@slogan()-@year

--- a/compiler/src/test/scala/play/twirl/compiler/test/CompilerSpec.scala
+++ b/compiler/src/test/scala/play/twirl/compiler/test/CompilerSpec.scala
@@ -300,6 +300,15 @@ class CompilerSpec extends AnyWordSpec with Matchers {
     hello.static("twirl", "something-else").toString.trim must include("""<header class="twirl">""")
   }
 
+  "compile successfully (local definitions)" in {
+    val helper = newCompilerHelper
+    val hello =
+      helper.compile[(() => Html)]("localDef.scala.html", "html.localDef")
+    hello.static().toString.trim must be(
+      "Play-Framework-Vienna-Austria-Europe-The High Velocity Web Framework For Java and Scala-2023"
+    )
+  }
+
   "compile successfully (block with tuple)" in {
     val helper = newCompilerHelper
     val hello  = helper.compile[(Seq[(String, String)] => Html)]("blockWithTuple.scala.html", "html.blockWithTuple")

--- a/parser/src/main/scala/play/twirl/parser/TreeNodes.scala
+++ b/parser/src/main/scala/play/twirl/parser/TreeNodes.scala
@@ -26,12 +26,12 @@ object TreeNodes {
   case class PosString(str: String) extends Positional {
     override def toString: String = str
   }
-  case class Def(name: PosString, params: PosString, code: Simple) extends Positional
-  case class Plain(text: String)                                   extends TemplateTree with Positional
-  case class Display(exp: ScalaExp)                                extends TemplateTree with Positional
-  case class Comment(msg: String)                                  extends TemplateTree with Positional
-  case class ScalaExp(parts: collection.Seq[ScalaExpPart])         extends TemplateTree with Positional
-  case class Simple(code: String)                                  extends ScalaExpPart with Positional
+  case class Def(name: PosString, params: PosString, resultType: Option[PosString], code: Simple) extends Positional
+  case class Plain(text: String)                           extends TemplateTree with Positional
+  case class Display(exp: ScalaExp)                        extends TemplateTree with Positional
+  case class Comment(msg: String)                          extends TemplateTree with Positional
+  case class ScalaExp(parts: collection.Seq[ScalaExpPart]) extends TemplateTree with Positional
+  case class Simple(code: String)                          extends ScalaExpPart with Positional
   case class Block(whitespace: String, args: Option[PosString], content: collection.Seq[TemplateTree])
       extends ScalaExpPart
       with Positional

--- a/parser/src/main/scala/play/twirl/parser/TwirlParser.scala
+++ b/parser/src/main/scala/play/twirl/parser/TwirlParser.scala
@@ -916,9 +916,9 @@ class TwirlParser(val shouldParseInclusiveDot: Boolean) {
 
       if (name != null) {
         val paramspos = input.offset()
-        val types     = Option(squareBrackets()).getOrElse(PosString(""))
+        val types     = Option(squareBrackets()).getOrElse("")
         val args      = several[String, ArrayBuffer[String]] { () => parentheses() }
-        val params    = position(PosString(types.toString + args.mkString), paramspos)
+        val params    = position(PosString(types + args.mkString), paramspos)
         if (params != null)
           return (name, params)
       } else input.regress(1) // don't consume @

--- a/parser/src/test/scala/play/twirl/parser/test/ParserSpec.scala
+++ b/parser/src/test/scala/play/twirl/parser/test/ParserSpec.scala
@@ -180,6 +180,140 @@ class ParserSpec extends AnyWordSpec with Matchers with Inside {
       }
     }
 
+    "handle local definitions" when {
+      "resultType is given" in {
+        val tmpl = parseTemplateString(
+          """@implicitField: FieldConstructor = @{ FieldConstructor(myFieldConstructorTemplate.f) }"""
+        )
+        val localDef = tmpl.defs(0)
+
+        localDef.name.str mustBe "implicitField"
+        localDef.name.pos.line mustBe 1
+        localDef.name.pos.column mustBe 2
+
+        val resultType = localDef.resultType.get
+        resultType.str mustBe "FieldConstructor"
+        resultType.pos.line mustBe 1
+        resultType.pos.column mustBe 17
+
+        localDef.params.str mustBe ""
+
+        localDef.code.code mustBe "{ FieldConstructor(myFieldConstructorTemplate.f) }"
+      }
+      "resultType is given without implicit prefixed" in {
+        val tmpl = parseTemplateString(
+          """@field: FieldConstructor = @{ FieldConstructor(myFieldConstructorTemplate.f) }"""
+        )
+        val localDef = tmpl.defs(0)
+
+        localDef.name.str mustBe "field"
+        localDef.name.pos.line mustBe 1
+        localDef.name.pos.column mustBe 2
+
+        val resultType = localDef.resultType.get
+        resultType.str mustBe "FieldConstructor"
+        resultType.pos.line mustBe 1
+        resultType.pos.column mustBe 9
+
+        localDef.params.str mustBe ""
+
+        localDef.code.code mustBe "{ FieldConstructor(myFieldConstructorTemplate.f) }"
+      }
+      "resultType with type is given" in {
+        val tmpl = parseTemplateString(
+          """@implicitField: FieldConstructor[FooType] = @{ FieldConstructor(myFieldConstructorTemplate.f) }"""
+        )
+        val localDef = tmpl.defs(0)
+
+        localDef.name.str mustBe "implicitField"
+        localDef.name.pos.line mustBe 1
+        localDef.name.pos.column mustBe 2
+
+        val resultType = localDef.resultType.get
+        resultType.str mustBe "FieldConstructor[FooType]"
+        resultType.pos.line mustBe 1
+        resultType.pos.column mustBe 17
+
+        localDef.params.str mustBe ""
+
+        localDef.code.code mustBe "{ FieldConstructor(myFieldConstructorTemplate.f) }"
+      }
+      "resultType is given without spaces" in {
+        val tmpl = parseTemplateString(
+          """@implicitField:FieldConstructor=@{ FieldConstructor(myFieldConstructorTemplate.f) }"""
+        )
+        val localDef = tmpl.defs(0)
+
+        localDef.name.str mustBe "implicitField"
+        localDef.name.pos.line mustBe 1
+        localDef.name.pos.column mustBe 2
+
+        val resultType = localDef.resultType.get
+        resultType.str mustBe "FieldConstructor"
+        resultType.pos.line mustBe 1
+        resultType.pos.column mustBe 16
+
+        localDef.params.str mustBe ""
+
+        localDef.code.code mustBe "{ FieldConstructor(myFieldConstructorTemplate.f) }"
+      }
+      "resultType and params are given" in {
+        val tmpl = parseTemplateString(
+          """@implicitField(foo: String, bar: Int): FieldConstructor = @{ FieldConstructor(myFieldConstructorTemplate.f) }"""
+        )
+        val localDef = tmpl.defs(0)
+
+        localDef.name.str mustBe "implicitField"
+        localDef.name.pos.line mustBe 1
+        localDef.name.pos.column mustBe 2
+
+        val resultType = localDef.resultType.get
+        resultType.str mustBe "FieldConstructor"
+        resultType.pos.line mustBe 1
+        resultType.pos.column mustBe 40
+
+        localDef.params.str mustBe "(foo: String, bar: Int)"
+        localDef.params.pos.line mustBe 1
+        localDef.params.pos.column mustBe 15
+
+        localDef.code.code mustBe "{ FieldConstructor(myFieldConstructorTemplate.f) }"
+      }
+      "no resultType and no params are given" in {
+        val tmpl = parseTemplateString(
+          """@implicitField = @{ FieldConstructor(myFieldConstructorTemplate.f) }"""
+        )
+        val localDef = tmpl.defs(0)
+
+        localDef.name.str mustBe "implicitField"
+        localDef.name.pos.line mustBe 1
+        localDef.name.pos.column mustBe 2
+
+        localDef.resultType mustBe None
+
+        localDef.params.str mustBe ""
+
+        localDef.code.code mustBe "{ FieldConstructor(myFieldConstructorTemplate.f) }"
+      }
+      "no resultType but params are given" in {
+        val tmpl = parseTemplateString(
+          """@implicitField(foo: String, bar: Int) = @{ FieldConstructor(myFieldConstructorTemplate.f) }"""
+        )
+        val localDef = tmpl.defs(0)
+
+        localDef.name.str mustBe "implicitField"
+        localDef.name.pos.line mustBe 1
+        localDef.name.pos.column mustBe 2
+
+        localDef.resultType mustBe None
+
+        localDef.params.str mustBe "(foo: String, bar: Int)"
+        localDef.params.pos.line mustBe 1
+        localDef.params.pos.column mustBe 15
+
+        localDef.code.code mustBe "{ FieldConstructor(myFieldConstructorTemplate.f) }"
+      }
+    }
+
     "handle string literals within parentheses" when {
       "with left parenthesis" in {
         parseStringSuccess("""@foo("(")""")


### PR DESCRIPTION
To define an implicit we need to prefix the name with `implicit`:
```scala
@implicitField = @{ ... }
```
this generates:
```scala
implicit def /*6.2*/implicitField = {{ ... }}
```

Scala 3 however complains:
```
[error] ./documentation/manual/working/javaGuide/main/forms/code/javaguide/forms/withFieldConstructor.scala.html:6:2:
[error]  result type of implicit definition needs to be given explicitly
[error] @implicitField = @{ ... }
[error]  ^
````

Until now it was not possible to define a result type, so this pull request adds support for that so we can now write:
```scala
@implicitField: FieldConstructor = @{ ... }
```
which generates:
```scala
implicit def /*6.2*/implicitField/*6.15*/:FieldConstructor = {{ ... }}
```

Works locally, tested with Play's Scala 3 pull requests, just needs some tests.