### PR TITLE
fix warning

### DIFF
--- a/compiler/src/main/scala/play/twirl/compiler/TwirlCompiler.scala
+++ b/compiler/src/main/scala/play/twirl/compiler/TwirlCompiler.scala
@@ -522,7 +522,7 @@ package """ :+ packageName :+ """
           val obj     = implicitly[Parse[Stat]].apply(input, dialect).get.asInstanceOf[Defn.Object]
           val templ   = obj.templ
           val defdef  = templ.stats.head.asInstanceOf[Decl.Def]
-          defdef.paramss
+          defdef.paramClauseGroups.headOption.map(_.paramClauses.map(_.values)).getOrElse(Nil)
         } catch {
           case e: ParseException => Nil
         }


### PR DESCRIPTION
```
[warn] /home/runner/work/twirl/twirl/compiler/src/main/scala/play/twirl/compiler/TwirlCompiler.scala:525:18: method paramss in trait Def is deprecated: 4.6.0
[warn]           defdef.paramss
[warn]                  ^
[warn] one warning found
```

