### PR TITLE
avoid deprecated `java.net.URL` constructor

### DIFF
--- a/compiler/src/test/scala/play/twirl/compiler/test/CompilerSpec.scala
+++ b/compiler/src/test/scala/play/twirl/compiler/test/CompilerSpec.scala
@@ -107,7 +107,7 @@ class CompilerSpec extends AnyWordSpec with Matchers {
       val helper = newCompilerHelper
       val result = helper
         .compile[((java.io.File, java.net.URL) => Html)]("argImports.scala.html", "html.argImports")
-        .static(new java.io.File("example"), new java.net.URL("http://example.org"))
+        .static(new java.io.File("example"), new java.net.URI("http://example.org").toURL)
         .toString
         .trim
       result must be("<p>file: example, url: http://example.org</p>")


### PR DESCRIPTION
deprecated since JDK 20

- https://bugs.openjdk.org/browse/JDK-8295949
- https://github.com/openjdk/jdk/commit/4338f527aa81350e3636dcfbcd2eb17ddaad3914
