### PR TITLE
Fix whitespaces after `else{...}` and `elseif{...}` is not shown

### DIFF
--- a/parser/src/main/scala/play/twirl/parser/TwirlParser.scala
+++ b/parser/src/main/scala/play/twirl/parser/TwirlParser.scala
@@ -73,7 +73,7 @@ import scala.util.parsing.input.OffsetPosition
  *   safeExpression : '@' parentheses
  *   ifExpression : '@' "if" parentheses expressionPart (elseIfCall)* elseCall?
  *   elseCall : whitespaceNoBreak? "else" whitespaceNoBreak? expressionPart
- *   elseIfCall : whitespaceNoBreak? "else if" parentheses expressionPart whitespaceNoBreak?
+ *   elseIfCall : whitespaceNoBreak? "else if" parentheses whitespaceNoBreak? expressionPart
  *   chainedMethods : ('.' methodCall)+
  *   expressionPart : chainedMethods | block | (whitespaceNoBreak scalaBlockChained) | parentheses
  *   expression : '@' methodCall expressionPart*
@@ -853,7 +853,6 @@ class TwirlParser(val shouldParseInclusiveDot: Boolean) {
       if (args != null) {
         val blk = expressionPart(blockArgsAllowed = true)
         if (blk != null) {
-          whitespaceNoBreak()
           Seq(Simple("else if" + args), blk)
         } else {
           null

--- a/parser/src/main/scala/play/twirl/parser/TwirlParser.scala
+++ b/parser/src/main/scala/play/twirl/parser/TwirlParser.scala
@@ -72,7 +72,7 @@ import scala.util.parsing.input.OffsetPosition
  *   complexExpr : parentheses
  *   safeExpression : '@' parentheses
  *   ifExpression : '@' "if" parentheses expressionPart (elseIfCall)* elseCall?
- *   elseCall : whitespaceNoBreak? "else" expressionPart whitespaceNoBreak?
+ *   elseCall : whitespaceNoBreak? "else" whitespaceNoBreak? expressionPart
  *   elseIfCall : whitespaceNoBreak? "else if" parentheses expressionPart whitespaceNoBreak?
  *   chainedMethods : ('.' methodCall)+
  *   expressionPart : chainedMethods | block | (whitespaceNoBreak scalaBlockChained) | parentheses

--- a/parser/src/main/scala/play/twirl/parser/TwirlParser.scala
+++ b/parser/src/main/scala/play/twirl/parser/TwirlParser.scala
@@ -874,7 +874,6 @@ class TwirlParser(val shouldParseInclusiveDot: Boolean) {
       whitespaceNoBreak()
       val blk = expressionPart(blockArgsAllowed = true)
       if (blk != null) {
-        whitespaceNoBreak()
         Seq(Simple("else"), blk)
       } else {
         null

--- a/parser/src/test/scala/play/twirl/parser/test/ParserSpec.scala
+++ b/parser/src/test/scala/play/twirl/parser/test/ParserSpec.scala
@@ -197,6 +197,23 @@ class ParserSpec extends AnyWordSpec with Matchers with Inside {
         afterWhitespaces mustBe Plain("Some plain text with whitespaces")
       }
 
+      "whitespaces after 'else if(condition) {...}' as plain" in {
+        val template = parseTemplateString(
+          """@if(condition) {ifblock body} else if(condition2) {elseifblock body}  Some plain text with whitespaces"""
+        )
+        val ifExpressions = template.content(0).asInstanceOf[Display].exp.parts
+        ifExpressions.head must be(Simple("if(condition)"))
+        val ifBlockBody = ifExpressions(1).asInstanceOf[Block].content(0)
+        ifBlockBody mustBe Plain("ifblock body")
+        val elseIfPart = ifExpressions(2)
+        elseIfPart mustBe Simple("else if(condition2)")
+        val elseBlockBody = ifExpressions(3).asInstanceOf[Block].content(0)
+        elseBlockBody mustBe Plain("elseifblock body")
+        val afterIfExpressionOfWhitespaces = template.content(1)
+        afterIfExpressionOfWhitespaces mustBe Plain("  ")
+        val afterWhitespaces = template.content(2)
+        afterWhitespaces mustBe Plain("Some plain text with whitespaces")
+      }
     }
 
     "handle local definitions" when {

--- a/parser/src/test/scala/play/twirl/parser/test/ParserSpec.scala
+++ b/parser/src/test/scala/play/twirl/parser/test/ParserSpec.scala
@@ -178,6 +178,25 @@ class ParserSpec extends AnyWordSpec with Matchers with Inside {
         val secondCaseBlockBody = secondCaseBlock(1).asInstanceOf[Block]
         secondCaseBlockBody.content(1).asInstanceOf[Plain].text mustBe "Not a nice string "
       }
+
+      "whitespaces after 'else {...}' as plain" in {
+        val template = parseTemplateString(
+          """@if(condition) {ifblock body} else {elseblock body}  Some plain text with whitespaces"""
+        )
+        val ifExpressions = template.content(0).asInstanceOf[Display].exp.parts
+        ifExpressions.head must be(Simple("if(condition)"))
+        val ifBlockBody = ifExpressions(1).asInstanceOf[Block].content(0)
+        ifBlockBody mustBe Plain("ifblock body")
+        val elsePart = ifExpressions(2)
+        elsePart mustBe Simple("else")
+        val elseBlockBody = ifExpressions(3).asInstanceOf[Block].content(0)
+        elseBlockBody mustBe Plain("elseblock body")
+        val afterIfExpressionOfWhitespaces = template.content(1)
+        afterIfExpressionOfWhitespaces mustBe Plain("  ")
+        val afterWhitespaces = template.content(2)
+        afterWhitespaces mustBe Plain("Some plain text with whitespaces")
+      }
+
     }
 
     "handle local definitions" when {


### PR DESCRIPTION
The parser does not recognize whitespace after `else {...}` as a plain, so it is not showing.

Refs #711