### PR TITLE
compiler: account for Scala 2 and 3 differences in generated varargs code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,14 @@ project/plugins/project/
 .bloop/
 
 compiler/version.properties
+
+.vscode/
+
+# Metals
+.metals/
+.bloop/
+project/metals.sbt
+metals.sbt
+
+# BSP
+.bsp/*

--- a/.gitignore
+++ b/.gitignore
@@ -14,8 +14,6 @@ project/plugins/project/
 .scala_dependencies
 .idea
 
-.bloop/
-
 compiler/version.properties
 
 .vscode/
@@ -25,6 +23,3 @@ compiler/version.properties
 .bloop/
 project/metals.sbt
 metals.sbt
-
-# BSP
-.bsp/*

--- a/compiler/src/main/java/play/japi/twirl/compiler/TwirlCompiler.java
+++ b/compiler/src/main/java/play/japi/twirl/compiler/TwirlCompiler.java
@@ -56,6 +56,7 @@ public class TwirlCompiler {
       List<String> constructorAnnotations,
       Codec codec,
       boolean inclusiveDot) {
+    String scalaVersion = play.twirl.compiler.BuildInfo$.MODULE$.scalaVersion();
     Seq<String> scalaAdditionalImports = toScalaSeq(additionalImports);
     Seq<String> scalaConstructorAnnotations = toScalaSeq(constructorAnnotations);
 
@@ -65,6 +66,7 @@ public class TwirlCompiler {
             sourceDirectory,
             generatedDirectory,
             formatterType,
+            scalaVersion,
             scalaAdditionalImports,
             scalaConstructorAnnotations,
             codec,

--- a/compiler/src/main/java/play/japi/twirl/compiler/TwirlCompiler.java
+++ b/compiler/src/main/java/play/japi/twirl/compiler/TwirlCompiler.java
@@ -66,7 +66,7 @@ public class TwirlCompiler {
             sourceDirectory,
             generatedDirectory,
             formatterType,
-            scalaVersion,
+            scala.Option.apply(scalaVersion),
             scalaAdditionalImports,
             scalaConstructorAnnotations,
             codec,

--- a/compiler/src/test/scala-2/play/twirl/compiler/test/Helper.scala
+++ b/compiler/src/test/scala-2/play/twirl/compiler/test/Helper.scala
@@ -11,7 +11,7 @@ import play.twirl.parser.TwirlIO
 object Helper {
   case class CompilationError(message: String, line: Int, column: Int) extends RuntimeException(message)
 
-  class CompilerHelper(sourceDir: File, generatedDir: File, generatedClasses: File) {
+  class CompilerHelper(sourceDir: File, val generatedDir: File, generatedClasses: File) {
     import java.net._
     import scala.collection.mutable
     import scala.reflect.internal.util.Position

--- a/compiler/src/test/scala-2/play/twirl/compiler/test/Helper.scala
+++ b/compiler/src/test/scala-2/play/twirl/compiler/test/Helper.scala
@@ -99,6 +99,7 @@ object Helper {
         sourceDir,
         generatedDir,
         "play.twirl.api.HtmlFormat",
+        scalaVersion,
         additionalImports = TwirlCompiler.defaultImports(scalaVersion) ++ additionalImports
       )
 

--- a/compiler/src/test/scala-2/play/twirl/compiler/test/Helper.scala
+++ b/compiler/src/test/scala-2/play/twirl/compiler/test/Helper.scala
@@ -6,6 +6,7 @@ package play.twirl.compiler
 package test
 
 import java.io._
+import play.twirl.parser.TwirlIO
 
 object Helper {
   case class CompilationError(message: String, line: Int, column: Int) extends RuntimeException(message)
@@ -99,8 +100,11 @@ object Helper {
         sourceDir,
         generatedDir,
         "play.twirl.api.HtmlFormat",
-        scalaVersion,
-        additionalImports = TwirlCompiler.defaultImports(scalaVersion) ++ additionalImports
+        Option(scalaVersion),
+        additionalImports = TwirlCompiler.defaultImports(scalaVersion) ++ additionalImports,
+        constructorAnnotations = Nil,
+        codec = TwirlIO.defaultCodec,
+        inclusiveDot = false
       )
 
       val mapper = GeneratedSource(generated)

--- a/compiler/src/test/scala-3/play/twirl/compiler/test/Helper.scala
+++ b/compiler/src/test/scala-3/play/twirl/compiler/test/Helper.scala
@@ -20,6 +20,7 @@ import dotty.tools.io.PlainDirectory
 import dotty.tools.io.Directory
 import dotty.tools.io.ClassPath
 import scala.jdk.CollectionConverters._
+import play.twirl.parser.TwirlIO
 
 object Helper {
   case class CompilationError(message: String, line: Int, column: Int) extends RuntimeException(message)
@@ -65,8 +66,11 @@ object Helper {
         sourceDir,
         generatedDir,
         "play.twirl.api.HtmlFormat",
-        scalaVersion,
-        additionalImports = TwirlCompiler.defaultImports(scalaVersion) ++ additionalImports
+        Option(scalaVersion),
+        additionalImports = TwirlCompiler.defaultImports(scalaVersion) ++ additionalImports,
+        constructorAnnotations = Nil,
+        codec = TwirlIO.defaultCodec,
+        inclusiveDot = false
       )
 
       val generated = generatedOpt.getOrElse {

--- a/compiler/src/test/scala-3/play/twirl/compiler/test/Helper.scala
+++ b/compiler/src/test/scala-3/play/twirl/compiler/test/Helper.scala
@@ -25,7 +25,7 @@ import play.twirl.parser.TwirlIO
 object Helper {
   case class CompilationError(message: String, line: Int, column: Int) extends RuntimeException(message)
 
-  class CompilerHelper(sourceDir: File, generatedDir: File, generatedClasses: File) {
+  class CompilerHelper(sourceDir: File, val generatedDir: File, generatedClasses: File) {
     import java.net._
     import scala.collection.mutable
 

--- a/sbt-twirl/src/main/scala/play/twirl/sbt/SbtTwirl.scala
+++ b/sbt-twirl/src/main/scala/play/twirl/sbt/SbtTwirl.scala
@@ -121,7 +121,8 @@ object SbtTwirl extends AutoPlugin {
         (compileTemplates / includeFilter).value,
         (compileTemplates / excludeFilter).value,
         Codec(sourceEncoding.value),
-        streams.value.log
+        streams.value.log,
+        scalaVersion.value
       )
     }
 

--- a/sbt-twirl/src/main/scala/play/twirl/sbt/TemplateCompiler.scala
+++ b/sbt-twirl/src/main/scala/play/twirl/sbt/TemplateCompiler.scala
@@ -20,7 +20,8 @@ object TemplateCompiler {
       includeFilter: FileFilter,
       excludeFilter: FileFilter,
       codec: Codec,
-      log: Logger
+      log: Logger,
+      scalaVersion: String
   ): Seq[File] = {
     try {
       syncGenerated(targetDirectory, codec)
@@ -32,6 +33,7 @@ object TemplateCompiler {
           sourceDirectory,
           targetDirectory,
           format,
+          scalaVersion,
           imports,
           constructorAnnotations,
           codec,

--- a/sbt-twirl/src/main/scala/play/twirl/sbt/TemplateCompiler.scala
+++ b/sbt-twirl/src/main/scala/play/twirl/sbt/TemplateCompiler.scala
@@ -33,7 +33,7 @@ object TemplateCompiler {
           sourceDirectory,
           targetDirectory,
           format,
-          scalaVersion,
+          Some(scalaVersion),
           imports,
           constructorAnnotations,
           codec,

--- a/sbt-twirl/src/main/scala/play/twirl/sbt/TemplateCompiler.scala
+++ b/sbt-twirl/src/main/scala/play/twirl/sbt/TemplateCompiler.scala
@@ -20,6 +20,29 @@ object TemplateCompiler {
       includeFilter: FileFilter,
       excludeFilter: FileFilter,
       codec: Codec,
+      log: Logger
+  ): Seq[File] = compile(
+    sourceDirectories,
+    targetDirectory,
+    templateFormats,
+    templateImports,
+    constructorAnnotations,
+    includeFilter,
+    excludeFilter,
+    codec,
+    log,
+    "2.13.x" // using a dummy scala version (not starting with "3." to generate Scala 2 code by default)
+  )
+
+  def compile(
+      sourceDirectories: Seq[File],
+      targetDirectory: File,
+      templateFormats: Map[String, String],
+      templateImports: Seq[String],
+      constructorAnnotations: Seq[String],
+      includeFilter: FileFilter,
+      excludeFilter: FileFilter,
+      codec: Codec,
       log: Logger,
       scalaVersion: String
   ): Seq[File] = {


### PR DESCRIPTION
This adds a bit of redudant overloads. The most important aspect for me now is that mima and tests pass plus a minor release can be shipped. At a later time, one can remove overloads and duplication, do a cleanup with a breaking change and bump major version or similar.