### PR TITLE
[Gradle] Use `processIsolation` instead of `classLoaderIsolation`

### DIFF
--- a/gradle-twirl/src/main/java/play/twirl/gradle/TwirlCompile.java
+++ b/gradle-twirl/src/main/java/play/twirl/gradle/TwirlCompile.java
@@ -72,7 +72,7 @@ public abstract class TwirlCompile extends DefaultTask {
       if (change.getFileType() == FileType.DIRECTORY) continue;
       WorkQueue workQueue =
           getWorkerExecutor()
-              .classLoaderIsolation(spec -> spec.getClasspath().from(getTwirlClasspath()));
+              .processIsolation(spec -> spec.getClasspath().from(getTwirlClasspath()));
 
       Map<String, String> templateFormats = getTemplateFormats().get();
       RelativeFile sourceFile =


### PR DESCRIPTION
Hi.
First of all, I appreciate your great work.
This is my first PR for the Play projects, so sorry in advance if I'm doing something wrong.

I was trying to migrate a few Play Framework projects to Gradle, but I couldn't migrate some of them because `compileTwirl` task gave me an out of memory error of JVM's Metaspace.
I was able to migrate a project that has dozens of views, but I couldn't which has around 1,000 views.
My PC has 32GB RAM, but increasing Xmx nor MaxMetaspaceSize didn't fix the issue.

After searching for a bit, I found [this Gradle's issue](https://github.com/gradle/gradle/issues/18313).
I forked the Twirl repo, replaced `classLoaderIsolation` with `processIsolation`, published it to `mavenLocal()` and using that SNAPSHOT version of the Twirl plugin from my local Maven repo actually fixed the problem.

I just filed a PR right away because it's a small change.
What are your thoughts on this change?

**Possibly related**
- https://github.com/playframework/twirl/issues/745
  - Specifically about OOM part

**Other projects doing the same fix**
- [sigstore-java](https://github.com/sigstore/sigstore-java/pull/283)
- [ktfmt-gradle](https://github.com/cortinico/ktfmt-gradle/pull/206)