### PR TITLE
Add support for sbt 2

### DIFF
--- a/docs/project/build.properties
+++ b/docs/project/build.properties
@@ -1,3 +1,3 @@
 # Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
 
-sbt.version=1.10.0
+sbt.version=2.0.0-M2

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,3 +1,3 @@
 # Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
 
-sbt.version=1.10.0
+sbt.version=2.0.0-M2


### PR DESCRIPTION
See 
- https://github.com/sbt/sbt/issues/7698
- **[sbt 2.x plugin migration wiki page with list of progress](https://github.com/sbt/sbt/wiki/sbt-2.x-plugin-migration)**
- https://github.com/playframework/playframework/pull/12897

We can't really do much at this point but to wait for other plugins to be released first that twirl depends on:
- [ ] ch.epfl.scala:sbt-bloop_sbt2.0.0-M2_3
- [ ] com.eed3si9n:sbt-buildinfo_sbt2.0.0-M2_3
- [ ] com.github.sbt:sbt-maven-plugin_sbt2.0.0-M2_3
- [ ] com.typesafe:sbt-mima-plugin_sbt2.0.0-M2_3
- [ ] org.scala-js:sbt-scalajs_sbt2.0.0-M2_3
- [ ] org.portable-scala:sbt-scalajs-crossproject_sbt2.0.0-M2_3
- [ ] com.lightbend.sbt:sbt-java-formatter_sbt2.0.0-M2_3
- [ ] de.heikoseeberger:sbt-header_sbt2.0.0-M2_3
- [ ] com.github.sbt:sbt-ci-release_sbt2.0.0-M2_3
- [ ] org.scalameta:sbt-scalafmt_sbt2.0.0-M2_3