### PR TITLE
Scalameta parsers 4.12.2 - no more `for3Use2_13` workaround

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -116,7 +116,7 @@ lazy val compiler = project
       }
     },
     libraryDependencies += parserCombinators(scalaVersion.value),
-    libraryDependencies += ("org.scalameta" %% "parsers" % "4.11.0").cross(CrossVersion.for3Use2_13),
+    libraryDependencies += "org.scalameta" %% "parsers" % "4.12.2",
     run / fork                              := true,
     buildInfoKeys                           := Seq[BuildInfoKey](scalaVersion),
     buildInfoPackage                        := "play.twirl.compiler",

--- a/build.sbt
+++ b/build.sbt
@@ -117,12 +117,12 @@ lazy val compiler = project
     },
     libraryDependencies += parserCombinators(scalaVersion.value),
     libraryDependencies += "org.scalameta" %% "parsers" % "4.12.2",
-    run / fork                              := true,
-    buildInfoKeys                           := Seq[BuildInfoKey](scalaVersion),
-    buildInfoPackage                        := "play.twirl.compiler",
-    publishM2                               := publishM2.dependsOn(saveCompilerVersion).value,
-    publish                                 := publish.dependsOn(saveCompilerVersion).value,
-    publishLocal                            := publishLocal.dependsOn(saveCompilerVersion).value
+    run / fork                             := true,
+    buildInfoKeys                          := Seq[BuildInfoKey](scalaVersion),
+    buildInfoPackage                       := "play.twirl.compiler",
+    publishM2                              := publishM2.dependsOn(saveCompilerVersion).value,
+    publish                                := publish.dependsOn(saveCompilerVersion).value,
+    publishLocal                           := publishLocal.dependsOn(saveCompilerVersion).value
   )
   .aggregate(parser)
   .dependsOn(apiJvm % Test, parser % "compile->compile;test->test")


### PR DESCRIPTION
details: https://github.com/scalameta/scalameta/releases/tag/v4.12.1