### PR TITLE
fix warning

### DIFF
--- a/compiler/src/main/scala/play/twirl/compiler/TwirlCompiler.scala
+++ b/compiler/src/main/scala/play/twirl/compiler/TwirlCompiler.scala
@@ -693,7 +693,7 @@ package """ :+ packageName :+ """
           val input   = Input.String(s"object FT { def signature$signature }")
           val obj     = implicitly[Parse[Stat]].apply(input, dialect).get.asInstanceOf[Defn.Object]
           val templ   = obj.templ
-          val defdef  = templ.stats.head.asInstanceOf[Decl.Def]
+          val defdef  = templ.body.stats.head.asInstanceOf[Decl.Def]
           defdef.paramClauseGroups.headOption.map(_.paramClauses.map(_.values)).getOrElse(Nil)
         } catch {
           case e: ParseException => Nil


### PR DESCRIPTION
```
[warn] /home/runner/work/twirl/twirl/compiler/src/main/scala/play/twirl/compiler/TwirlCompiler.scala:696:31: method stats in trait Template is deprecated: 4.9.9
[warn]           val defdef  = templ.stats.head.asInstanceOf[Decl.Def]
[warn]                               ^
```

https://github.com/scalameta/scalameta/commit/0281ed2790f9260c59b2accc65d45c4204b200f0#diff-ecb16d4dff6f70cb361071edf42ae6efc0761fb002cf9c84c2776e8ab7092d7fR1208