### PR TITLE
[2.0.x] Scalameta parsers 4.13.2 - no more `for3Use2_13` workaround

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -116,13 +116,13 @@ lazy val compiler = project
       }
     },
     libraryDependencies += parserCombinators(scalaVersion.value),
-    libraryDependencies += ("org.scalameta" %% "parsers" % "4.11.2").cross(CrossVersion.for3Use2_13),
-    run / fork                              := true,
-    buildInfoKeys                           := Seq[BuildInfoKey](scalaVersion),
-    buildInfoPackage                        := "play.twirl.compiler",
-    publishM2                               := publishM2.dependsOn(saveCompilerVersion).value,
-    publish                                 := publish.dependsOn(saveCompilerVersion).value,
-    publishLocal                            := publishLocal.dependsOn(saveCompilerVersion).value
+    libraryDependencies += "org.scalameta" %% "parsers" % "4.13.2",
+    run / fork                             := true,
+    buildInfoKeys                          := Seq[BuildInfoKey](scalaVersion),
+    buildInfoPackage                       := "play.twirl.compiler",
+    publishM2                              := publishM2.dependsOn(saveCompilerVersion).value,
+    publish                                := publish.dependsOn(saveCompilerVersion).value,
+    publishLocal                           := publishLocal.dependsOn(saveCompilerVersion).value
   )
   .aggregate(parser)
   .dependsOn(apiJvm % Test, parser % "compile->compile;test->test")


### PR DESCRIPTION
- Backport of #866

I looked into the scalameta parsers projects - it should be ok to just upgrade to the latest version as long as our tests pass.

Also good thing is that we can now also use the native Scala 3 artifact and starting with 4.9.9 (which we ship in latest twirl) parsers does not depend on `protobuf-java` anyomore which has vulnerabilities.