### PR TITLE
scala-parser-combinators v1 for Scala 2.12, v2 for 2.13+

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -11,8 +11,8 @@ val ScalaTestVersion = "3.2.19"
 
 def parserCombinators(scalaVersion: String) = "org.scala-lang.modules" %% "scala-parser-combinators" % {
   CrossVersion.partialVersion(scalaVersion) match {
-    case Some((2, _)) => "1.1.2"
-    case _            => "2.4.0"
+    case Some((2, 12)) => "1.1.2"
+    case _             => "2.4.0"
   }
 }
 


### PR DESCRIPTION
- Not really needed for https://github.com/playframework/playframework/pull/13197 but we should do the same everywhere
  - For Play this PR here is not so relevant, because twirl uses scala-parser-combinators only in twirl-compiler and twirl-parser, which are only pulled in from the sbt-plugin - which runs with Scala 2.12 anyway. Play does not pull them in as normal libs which then would run with Scala 2.13. But like written before, we should stay consistent with the other PRs and libraries.