### PR TITLE
[2.0.x] Stabilize Gradle Twirl import order

### DIFF
--- a/compiler/src/main/java/play/japi/twirl/compiler/TwirlCompiler.java
+++ b/compiler/src/main/java/play/japi/twirl/compiler/TwirlCompiler.java
@@ -8,6 +8,8 @@ import java.io.File;
 import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
@@ -24,8 +26,10 @@ public class TwirlCompiler {
   static {
     String scalaVersion = play.twirl.compiler.BuildInfo$.MODULE$.scalaVersion();
     DEFAULT_IMPORTS =
-        Set.copyOf(
-            toJavaList(play.twirl.compiler.TwirlCompiler$.MODULE$.defaultImports(scalaVersion)));
+        Collections.unmodifiableSet(
+            new LinkedHashSet<>(
+                toJavaList(
+                    play.twirl.compiler.TwirlCompiler$.MODULE$.defaultImports(scalaVersion))));
   }
 
   public static Optional<File> compile(

--- a/compiler/src/test/java/play/japi/twirl/compiler/TwirlCompilerTest.java
+++ b/compiler/src/test/java/play/japi/twirl/compiler/TwirlCompilerTest.java
@@ -14,6 +14,8 @@ import java.nio.file.Path;
 import java.nio.file.SimpleFileVisitor;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 import java.util.Optional;
 import org.junit.Test;
 
@@ -47,6 +49,28 @@ public class TwirlCompilerTest {
             TwirlCompiler.DEFAULT_IMPORTS,
             new ArrayList<String>());
     assertFalse(recompilationResult.isPresent());
+  }
+
+  @Test
+  public void defaultImportsHaveDeterministicOrder() {
+    String wildcard =
+        play.twirl.compiler.BuildInfo$.MODULE$.scalaVersion().startsWith("3.") ? "*" : "_";
+    List<String> expected =
+        new ArrayList<>(
+            Arrays.asList(
+                "_root_.play.twirl.api.TwirlFeatureImports." + wildcard,
+                "_root_.play.twirl.api.TwirlHelperImports." + wildcard));
+    if ("*".equals(wildcard)) {
+      expected.add("scala.language.adhocExtensions");
+    }
+    expected.addAll(
+        Arrays.asList(
+            "_root_.play.twirl.api.Html",
+            "_root_.play.twirl.api.JavaScript",
+            "_root_.play.twirl.api.Txt",
+            "_root_.play.twirl.api.Xml"));
+
+    assertEquals(expected, new ArrayList<>(TwirlCompiler.DEFAULT_IMPORTS));
   }
 
   private static void deleteRecursively(File directory) {

--- a/gradle-twirl/src/main/java/play/twirl/gradle/internal/TwirlCompileAction.java
+++ b/gradle-twirl/src/main/java/play/twirl/gradle/internal/TwirlCompileAction.java
@@ -4,7 +4,8 @@
 package play.twirl.gradle.internal;
 
 import java.io.File;
-import java.util.Collection;
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import org.gradle.api.logging.Logger;
 import org.gradle.api.logging.Logging;
@@ -68,7 +69,8 @@ public abstract class TwirlCompileAction implements WorkAction<TwirlCompileParam
       String formatterType = getParameters().getFormatterType().get();
       String extension = getParameters().getFormatExtension().get();
       getParameters().getTemplateImports().addAll(TwirlCompiler.DEFAULT_IMPORTS);
-      Collection<String> imports = getParameters().getTemplateImports().get();
+      List<String> imports = new ArrayList<>(getParameters().getTemplateImports().get());
+      Collections.sort(imports);
       List<String> constructorAnnotations = getParameters().getConstructorAnnotations().get();
       String sourceEncoding = getParameters().getSourceEncoding().get();
       if (LOGGER.isInfoEnabled()) {


### PR DESCRIPTION
- Fixes #1196

Gradle receives template imports through a `SetProperty`, so the order can vary between runs. That order is part of both the generated import block and the template hash.

Sort the Gradle import list before formatting it, and keep the Java `DEFAULT_IMPORTS` set in compiler-defined order so default imports are deterministic too.